### PR TITLE
Add Kept flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
+## 1.2.0 - 2016-12-10
+
+- `is_kept` flag added.
+
 ## 1.1.0 - 2016-09-25
 
 - `is_published` flag added.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 [![Releases](https://img.shields.io/github/release/cybercog/laravel-eloquent-flag.svg?style=flat-square)](https://github.com/cybercog/laravel-eloquent-flag/releases)
 [![License](https://img.shields.io/github/license/cybercog/laravel-eloquent-flag.svg?style=flat-square)](https://github.com/cybercog/laravel-eloquent-flag/blob/master/LICENSE)
 
-Eloquent flagged attributes behavior.
+Eloquent flagged attributes behavior. Add commonly used flags to models very quick and easy.
 
 ## Available flags list
 
 - `is_active`
 - `is_published`
+- `is_kept`
 
 ## Installation
 
@@ -131,6 +132,87 @@ Post::where('id', 4)->publish();
 ```shell
 Post::where('id', 4)->unpublish();
 ```
+
+### Setup a keepable model
+
+Keep functionality required when you are trying to attach related models before parent one isn't saved.
+
+**Issue:**
+
+1. User press `Create Post` button.
+2. Create post form has image uploader.
+3. On image uploading user can't attach image to post before it wouldn't been stored in database.
+
+**Solution:**
+
+1. Add `HasKeptFlag` trait to model (and add boolean `is_kept` column to database).
+2. Create empty model on form loading (it will has `is_kept = 0` by default).
+3. Feel free to add any relations to the model.
+
+*Model will be marked as required to be kept as soon as client will save\update model for the first time.*
+
+*Remove the unkept models on a predetermined schedule (once a week for example).*
+
+```php
+<?php
+
+namespace App\Models;
+
+use Cog\Flag\Traits\HasKeptFlag;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasKeptFlag;
+}
+```
+
+Your model is now can be marked to be kept!
+
+*Model must have boolean `is_kept` column in database table.*
+
+By default all records that have a `is_kept` equals to 0 will be excluded from your query results. To include unkept records, all you need to do is call the `withUnkept()` method on your query.
+
+### Available functions
+
+#### Get only kept models
+
+```shell
+Post::all();
+Post::withoutUnkept();
+```
+
+#### Get only unkept models
+
+```shell
+Post::onlyUnkept();
+```
+
+#### Get kept + unkept models
+
+```shell
+Post::withUnkept();
+```
+
+#### Keep model
+
+```shell
+Post::where('id', 4)->keep();
+```
+
+#### Unkeep model
+
+```shell
+Post::where('id', 4)->unkeep();
+```
+
+#### Get unkept models which older than hours
+
+```shell
+Post::onlyUnkeptOlderThanHours(4);
+```
+
+Output will have all unkept models created earlier than 4 hours ago.
 
 ## Testing
 

--- a/src/Scopes/ActiveFlagScope.php
+++ b/src/Scopes/ActiveFlagScope.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Flag\Scopes;
 
-use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -55,7 +55,7 @@ class ActiveFlagScope implements Scope
     }
 
     /**
-     * Add the activate extension to the builder.
+     * Add the `activate` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
@@ -70,7 +70,7 @@ class ActiveFlagScope implements Scope
     }
 
     /**
-     * Add the deactivate extension to the builder.
+     * Add the `deactivate` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
@@ -83,7 +83,7 @@ class ActiveFlagScope implements Scope
     }
 
     /**
-     * Add the with-inactive extension to the builder.
+     * Add the `withInactive` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
@@ -96,7 +96,7 @@ class ActiveFlagScope implements Scope
     }
 
     /**
-     * Add the without-inactive extension to the builder.
+     * Add the `withoutInactive` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
@@ -109,7 +109,7 @@ class ActiveFlagScope implements Scope
     }
 
     /**
-     * Add the only-inactive extension to the builder.
+     * Add the `onlyInactive` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void

--- a/src/Scopes/KeptFlagScope.php
+++ b/src/Scopes/KeptFlagScope.php
@@ -16,18 +16,18 @@ use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Class PublishedFlagScope.
+ * Class KeptFlagScope.
  *
  * @package Cog\Flag\Scopes
  */
-class PublishedFlagScope implements Scope
+class KeptFlagScope implements Scope
 {
     /**
      * All of the extensions to be added to the builder.
      *
      * @var array
      */
-    protected $extensions = ['Publish', 'Unpublish', 'WithUnpublished', 'WithoutUnpublished', 'OnlyUnpublished'];
+    protected $extensions = ['Keep', 'Unkeep', 'WithUnkept', 'WithoutUnkept', 'OnlyUnkept'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -38,7 +38,7 @@ class PublishedFlagScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        return $builder->where('is_published', 1);
+        return $builder->where('is_kept', 1);
     }
 
     /**
@@ -55,69 +55,69 @@ class PublishedFlagScope implements Scope
     }
 
     /**
-     * Add the `publish` extension to the builder.
+     * Add the `keep` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addPublish(Builder $builder)
+    protected function addKeep(Builder $builder)
     {
-        $builder->macro('publish', function (Builder $builder) {
-            $builder->withUnpublished();
+        $builder->macro('keep', function (Builder $builder) {
+            $builder->withUnkept();
 
-            return $builder->update(['is_published' => 1]);
+            return $builder->update(['is_kept' => 1]);
         });
     }
 
     /**
-     * Add the `unpublish` extension to the builder.
+     * Add the `unkeep` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addUnpublish(Builder $builder)
+    protected function addUnkeep(Builder $builder)
     {
-        $builder->macro('unpublish', function (Builder $builder) {
-            return $builder->update(['is_published' => 0]);
+        $builder->macro('unkeep', function (Builder $builder) {
+            return $builder->update(['is_kept' => 0]);
         });
     }
 
     /**
-     * Add the `withUnpublished` extension to the builder.
+     * Add the `withUnkept` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithUnpublished(Builder $builder)
+    protected function addWithUnkept(Builder $builder)
     {
-        $builder->macro('withUnpublished', function (Builder $builder) {
+        $builder->macro('withUnkept', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutUnpublished` extension to the builder.
+     * Add the `withoutUnkept` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutUnpublished(Builder $builder)
+    protected function addWithoutUnkept(Builder $builder)
     {
-        $builder->macro('withoutUnpublished', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_published', 1);
+        $builder->macro('withoutUnkept', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_kept', 1);
         });
     }
 
     /**
-     * Add the `onlyUnpublished` extension to the builder.
+     * Add the `onlyUnkept` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyUnpublished(Builder $builder)
+    protected function addOnlyUnkept(Builder $builder)
     {
-        $builder->macro('onlyUnpublished', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_published', 0);
+        $builder->macro('onlyUnkept', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_kept', 0);
         });
     }
 }

--- a/src/Traits/HasKeptFlag.php
+++ b/src/Traits/HasKeptFlag.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits;
+
+use Carbon\Carbon;
+use Cog\Flag\Scopes\KeptFlagScope;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Class HasKeptFlag.
+ *
+ * @package Cog\Flag\Traits
+ */
+trait HasKeptFlag
+{
+    /**
+     * Boot the has kept flag trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasKeptFlag()
+    {
+        static::addGlobalScope(new KeptFlagScope);
+
+        static::creating(function ($entity) {
+            if (!$entity->is_kept) {
+                $entity->is_kept = false;
+            }
+        });
+
+        static::updating(function ($entity) {
+            if (!$entity->is_kept) {
+                $entity->is_kept = true;
+            }
+        });
+    }
+
+    /**
+     * Determine if the model instance has `is_kept` state.
+     *
+     * @return bool
+     */
+    public function isKept()
+    {
+        return (bool) $this->is_kept;
+    }
+
+    /**
+     * Get unkept models that are older than the given number of hours.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param int $hours
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOnlyUnkeptOlderThanHours(Builder $builder, $hours)
+    {
+        return $builder->onlyUnkept()
+            ->where(static::getCreatedAtColumn(), '<=', Carbon::now()->subHours($hours)->toDateTimeString());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Flag\Tests;
 
-use Cog\Flag\Providers\FlagServiceProvider;
 use Illuminate\Support\Facades\File;
+use Cog\Flag\Providers\FlagServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 /**

--- a/tests/database/factories/EntityWithKeptFlagFactory.php
+++ b/tests/database/factories/EntityWithKeptFlagFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$factory->define(\Cog\Flag\Tests\Stubs\Models\EntityWithKeptFlag::class, function (\Faker\Generator $faker) {
+    return [
+        'name' => $faker->word,
+        'is_kept' => false,
+    ];
+});

--- a/tests/database/migrations/2016_09_25_182750_create_entity_with_kept_flag_table.php
+++ b/tests/database/migrations/2016_09_25_182750_create_entity_with_kept_flag_table.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Class CreateEntityWithKeptFlagTable.
+ */
+class CreateEntityWithKeptFlagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('entity_with_kept_flag', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('is_kept')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('entity_with_kept_flag');
+    }
+}

--- a/tests/stubs/Models/EntityWithKeptFlag.php
+++ b/tests/stubs/Models/EntityWithKeptFlag.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Stubs\Models;
+
+use Cog\Flag\Traits\HasKeptFlag;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class EntityWithKeptFlag.
+ *
+ * @package Cog\Flag\Tests\Stubs\Models
+ */
+class EntityWithKeptFlag extends Model
+{
+    use HasKeptFlag;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'entity_with_kept_flag';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'is_kept' => 'bool',
+    ];
+}

--- a/tests/unit/Scopes/ActiveFlagScopeTest.php
+++ b/tests/unit/Scopes/ActiveFlagScopeTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit;
+namespace Cog\Flag\Tests\Unit\Scopes;
 
-use Cog\Flag\Tests\Stubs\Models\EntityWithActiveFlag;
 use Cog\Flag\Tests\TestCase;
+use Cog\Flag\Tests\Stubs\Models\EntityWithActiveFlag;
 
 /**
- * Class HasActiveFlagTest.
+ * Class ActiveFlagScopeTest.
  *
- * @package Cog\Merchant\Tests\Unit
+ * @package Cog\Merchant\Tests\Unit\Scopes
  */
-class HasActiveFlagTest extends TestCase
+class ActiveFlagScopeTest extends TestCase
 {
     /** @test */
     public function it_can_get_only_active()

--- a/tests/unit/Scopes/KeptFlagScopeTest.php
+++ b/tests/unit/Scopes/KeptFlagScopeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Unit\Scopes;
+
+use Cog\Flag\Tests\TestCase;
+use Cog\Flag\Tests\Stubs\Models\EntityWithKeptFlag;
+
+/**
+ * Class KeptFlagScopeTest.
+ *
+ * @package Cog\Merchant\Tests\Unit\Scopes
+ */
+class KeptFlagScopeTest extends TestCase
+{
+    /** @test */
+    public function it_can_get_only_kept_models()
+    {
+        factory(EntityWithKeptFlag::class, 3)->create([
+            'is_kept' => true,
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+        ]);
+
+        $entities = EntityWithKeptFlag::all();
+
+        $this->assertCount(3, $entities);
+    }
+
+    /** @test */
+    public function it_can_get_without_unkept()
+    {
+        factory(EntityWithKeptFlag::class, 3)->create([
+            'is_kept' => true,
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+        ]);
+
+        $entities = EntityWithKeptFlag::withoutUnkept()->get();
+
+        $this->assertCount(3, $entities);
+    }
+
+    /** @test */
+    public function it_can_get_only_unkept()
+    {
+        factory(EntityWithKeptFlag::class, 3)->create([
+            'is_kept' => true,
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+        ]);
+
+        $entities = EntityWithKeptFlag::onlyUnkept()->get();
+
+        $this->assertCount(2, $entities);
+    }
+
+    /** @test */
+    public function it_can_keep_model()
+    {
+        $method = factory(EntityWithKeptFlag::class)->create([
+            'is_kept' => false,
+        ]);
+
+        EntityWithKeptFlag::where('id', $method->id)->keep();
+
+        $method = EntityWithKeptFlag::where('id', $method->id)->first();
+
+        $this->assertTrue($method->is_kept);
+    }
+
+    /** @test */
+    public function it_can_deactivate_model()
+    {
+        $method = factory(EntityWithKeptFlag::class)->create([
+            'is_kept' => true,
+        ]);
+
+        EntityWithKeptFlag::where('id', $method->id)->unkeep();
+
+        $method = EntityWithKeptFlag::withUnkept()->where('id', $method->id)->first();
+
+        $this->assertFalse($method->is_kept);
+    }
+}

--- a/tests/unit/Scopes/PublishedFlagScopeTest.php
+++ b/tests/unit/Scopes/PublishedFlagScopeTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit;
+namespace Cog\Flag\Tests\Unit\Scopes;
 
-use Cog\Flag\Tests\Stubs\Models\EntityWithPublishedFlag;
 use Cog\Flag\Tests\TestCase;
+use Cog\Flag\Tests\Stubs\Models\EntityWithPublishedFlag;
 
 /**
- * Class HasPublishedFlagTest.
+ * Class PublishedFlagScopeTest.
  *
- * @package Cog\Merchant\Tests\Unit
+ * @package Cog\Merchant\Tests\Unit\Scopes
  */
-class HasPublishedFlagTest extends TestCase
+class PublishedFlagScopeTest extends TestCase
 {
     /** @test */
     public function it_can_get_only_active()

--- a/tests/unit/Traits/HasKeptFlagTest.php
+++ b/tests/unit/Traits/HasKeptFlagTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Unit\Traits;
+
+use Carbon\Carbon;
+use Cog\Flag\Tests\TestCase;
+use Cog\Flag\Tests\Stubs\Models\EntityWithKeptFlag;
+
+/**
+ * Class HasKeptFlagTest.
+ *
+ * @package Cog\Merchant\Tests\Unit\Traits
+ */
+class HasKeptFlagTest extends TestCase
+{
+    /** @test */
+    public function it_sets_is_kept_false_on_create()
+    {
+        $entity = new EntityWithKeptFlag([
+            'name' => 'test',
+        ]);
+        $entity->save();
+
+        $this->assertFalse($entity->is_kept);
+    }
+
+    /** @test */
+    public function it_sets_is_kept_true_on_any_update()
+    {
+        $entity = factory(EntityWithKeptFlag::class)->create([
+            'is_kept' => false,
+        ]);
+
+        $entity->update([
+            'name' => 'new-name',
+        ]);
+
+        $this->assertTrue($entity->is_kept);
+    }
+
+    /** @test */
+    public function it_can_get_unkept_older_than_hours()
+    {
+        factory(EntityWithKeptFlag::class, 3)->create([
+            'is_kept' => true,
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+            'created_at' => Carbon::now()->subHours(4)->toDateTimeString(),
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+            'created_at' => Carbon::now()->subHours(2)->toDateTimeString(),
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+        ]);
+
+        $entities = EntityWithKeptFlag::onlyUnkeptOlderThanHours(4)->get();
+
+        $this->assertCount(2, $entities);
+    }
+}


### PR DESCRIPTION
Adds `is_kept` flag to models.

**Issue:**

1. User press `Create Post` button.
2. Create post form has image uploader.
3. On image uploading user can't attach image to post before it wouldn't been stored in database.

**Solution:**

1. Add `HasKeptFlag` trait to model (and add boolean `is_kept` column to database).
2. Create empty model on form loading (it will has `is_kept = 0` by default).
3. Feel free to add any relations to the model.

*Model will be marked as required to be kept as soon as client will save\update model for the first time.*

*Remove the unkept models on a predetermined schedule (once a week for example).*
