### PR TITLE
Flags separated to classic and inverse. Expired Inverse flag added

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,3 +4,4 @@ disabled:
   - concat_without_spaces
   - phpdoc_no_package
   - logical_not_operators_with_successor_space
+  - length_ordered_imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
+## 2.0.0 - 2016-01-04
+
+#### Breaking changes
+
+- Namespaces of flag's traits received `Classic` at the end: `Cog\Flag\Traits\Classic`.
+- Namespaces of flag's scopes received `Classic` at the end: `Cog\Flag\Scopes\Classic`.
+
+#### Added
+
+- `Inverse Logic` flags group. Hides entities if flag not set.
+- `is_expired` inverse boolean flag added.
+
 ## 1.5.0 - 2016-12-31
 
 - `is_approved` boolean flag added.

--- a/README.md
+++ b/README.md
@@ -18,20 +18,26 @@ Eloquent flagged attributes behavior. Add commonly used flags to models very qui
 
 ## Available flags list
 
-| Trait name | Database columns | Flag type |
-| ---------- | ---------------- | --------- |
-| `HasAcceptedFlag` | `is_accepted` | Boolean |
-| `HasActiveFlag` | `is_active` | Boolean |
-| `HasApprovedFlag` | `is_approved` | Boolean |
-| `HasKeptFlag` | `is_kept` | Boolean |
-| `HasPublishedFlag` | `is_published` | Boolean |
-| `HasVerifiedFlag` | `is_verified` | Boolean |
+| Trait name | Database columns | Flag type | Logic |
+| ---------- | ---------------- | --------- | ----- |
+| `HasAcceptedFlag` | `is_accepted` | Boolean | Classic |
+| `HasActiveFlag` | `is_active` | Boolean | Classic |
+| `HasApprovedFlag` | `is_approved` | Boolean | Classic |
+| `HasExpiredInverseFlag` | `is_expired` | Boolean | Inverse |
+| `HasKeptFlag` | `is_kept` | Boolean | Classic |
+| `HasPublishedFlag` | `is_published` | Boolean | Classic |
+| `HasVerifiedFlag` | `is_verified` | Boolean | Classic |
 
 ## How it works
 
 Eloquent Flag is an easy way to add flagged attributes to eloquent models. All flags has their own trait which adds global scopes to desired entity.
 
-The main logic of the flags: If flag is `false` - entity should be hidden from the query results. Omitted entities could be retrieved by using special global scope methods.  
+All flags separated on 2 logical groups:
+
+- `Classic` flags displays only entities with flag setted as `true`.
+- `Inverse` flags displays only entities with flag setted as `false`. 
+
+Omitted entities could be retrieved by using special global scope methods, unique for each flag.
 
 ## Installation
 
@@ -60,7 +66,7 @@ And then include the service provider within `app/config/app.php`.
 
 namespace App\Models;
 
-use Cog\Flag\Traits\HasActiveFlag;
+use Cog\Flag\Traits\Classic\HasActiveFlag;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -111,7 +117,7 @@ Post::where('id', 4)->deactivate();
 
 namespace App\Models;
 
-use Cog\Flag\Traits\HasAcceptedFlag;
+use Cog\Flag\Traits\Classic\HasAcceptedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -162,7 +168,7 @@ Post::where('id', 4)->unaccept();
 
 namespace App\Models;
 
-use Cog\Flag\Traits\HasApprovedFlag;
+use Cog\Flag\Traits\Classic\HasApprovedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -213,7 +219,7 @@ Post::where('id', 4)->unapprove();
 
 namespace App\Models;
 
-use Cog\Flag\Traits\HasPublishedFlag;
+use Cog\Flag\Traits\Classic\HasPublishedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -264,7 +270,7 @@ Post::where('id', 4)->unpublish();
 
 namespace App\Models;
 
-use Cog\Flag\Traits\HasVerifiedFlag;
+use Cog\Flag\Traits\Classic\HasVerifiedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -336,7 +342,7 @@ Keep functionality required when you are trying to attach related models before 
 
 namespace App\Models;
 
-use Cog\Flag\Traits\HasKeptFlag;
+use Cog\Flag\Traits\Classic\HasKeptFlag;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -391,6 +397,57 @@ Post::onlyUnkeptOlderThanHours(4);
 ```
 
 Output will have all unkept models created earlier than 4 hours ago.
+
+### Setup an expirable model
+
+```php
+<?php
+
+namespace App\Models;
+
+use Cog\Flag\Traits\Inverse\HasExpiredFlag;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasExpiredFlag;
+}
+```
+
+*Model must have boolean `is_expired` column in database table.*
+
+### Available functions
+
+#### Get only not expired models
+
+```shell
+Post::all();
+Post::withoutExpired();
+```
+
+#### Get only expired models
+
+```shell
+Post::onlyExpired();
+```
+
+#### Get expired + not expired models
+
+```shell
+Post::withExpired();
+```
+
+#### Set expire flag to model
+
+```shell
+Post::where('id', 4)->expire();
+```
+
+#### Remove expire flag from model
+
+```shell
+Post::where('id', 4)->unexpire();
+```
 
 ## Testing
 

--- a/src/Providers/FlagServiceProvider.php
+++ b/src/Providers/FlagServiceProvider.php
@@ -16,7 +16,7 @@ use Illuminate\Support\ServiceProvider;
 /**
  * Class FlagServiceProvider.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Providers
  */
 class FlagServiceProvider extends ServiceProvider
 {

--- a/src/Scopes/Classic/AcceptedFlagScope.php
+++ b/src/Scopes/Classic/AcceptedFlagScope.php
@@ -9,25 +9,25 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Scopes;
+namespace Cog\Flag\Scopes\Classic;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Class PublishedFlagScope.
+ * Class AcceptedFlagScope.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Scopes\Classic
  */
-class PublishedFlagScope implements Scope
+class AcceptedFlagScope implements Scope
 {
     /**
      * All of the extensions to be added to the builder.
      *
      * @var array
      */
-    protected $extensions = ['Publish', 'Unpublish', 'WithUnpublished', 'WithoutUnpublished', 'OnlyUnpublished'];
+    protected $extensions = ['Accept', 'Unaccept', 'WithUnaccepted', 'WithoutUnaccepted', 'OnlyUnaccepted'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -38,7 +38,7 @@ class PublishedFlagScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        return $builder->where('is_published', 1);
+        return $builder->where('is_accepted', 1);
     }
 
     /**
@@ -55,69 +55,69 @@ class PublishedFlagScope implements Scope
     }
 
     /**
-     * Add the `publish` extension to the builder.
+     * Add the `accept` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addPublish(Builder $builder)
+    protected function addAccept(Builder $builder)
     {
-        $builder->macro('publish', function (Builder $builder) {
-            $builder->withUnpublished();
+        $builder->macro('accept', function (Builder $builder) {
+            $builder->withUnaccepted();
 
-            return $builder->update(['is_published' => 1]);
+            return $builder->update(['is_accepted' => 1]);
         });
     }
 
     /**
-     * Add the `unpublish` extension to the builder.
+     * Add the `unaccept` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addUnpublish(Builder $builder)
+    protected function addUnaccept(Builder $builder)
     {
-        $builder->macro('unpublish', function (Builder $builder) {
-            return $builder->update(['is_published' => 0]);
+        $builder->macro('unaccept', function (Builder $builder) {
+            return $builder->update(['is_accepted' => 0]);
         });
     }
 
     /**
-     * Add the `withUnpublished` extension to the builder.
+     * Add the `withUnaccepted` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithUnpublished(Builder $builder)
+    protected function addWithUnaccepted(Builder $builder)
     {
-        $builder->macro('withUnpublished', function (Builder $builder) {
+        $builder->macro('withUnaccepted', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutUnpublished` extension to the builder.
+     * Add the `withoutUnaccepted` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutUnpublished(Builder $builder)
+    protected function addWithoutUnaccepted(Builder $builder)
     {
-        $builder->macro('withoutUnpublished', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_published', 1);
+        $builder->macro('withoutUnaccepted', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_accepted', 1);
         });
     }
 
     /**
-     * Add the `onlyUnpublished` extension to the builder.
+     * Add the `onlyUnaccepted` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyUnpublished(Builder $builder)
+    protected function addOnlyUnaccepted(Builder $builder)
     {
-        $builder->macro('onlyUnpublished', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_published', 0);
+        $builder->macro('onlyUnaccepted', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_accepted', 0);
         });
     }
 }

--- a/src/Scopes/Classic/ActiveFlagScope.php
+++ b/src/Scopes/Classic/ActiveFlagScope.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Scopes;
+namespace Cog\Flag\Scopes\Classic;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class ActiveFlagScope.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Scopes\Classic
  */
 class ActiveFlagScope implements Scope
 {

--- a/src/Scopes/Classic/ApprovedFlagScope.php
+++ b/src/Scopes/Classic/ApprovedFlagScope.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Scopes;
+namespace Cog\Flag\Scopes\Classic;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class ApprovedFlagScope.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Scopes\Classic
  */
 class ApprovedFlagScope implements Scope
 {

--- a/src/Scopes/Classic/KeptFlagScope.php
+++ b/src/Scopes/Classic/KeptFlagScope.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Scopes;
+namespace Cog\Flag\Scopes\Classic;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class KeptFlagScope.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Scopes\Classic
  */
 class KeptFlagScope implements Scope
 {

--- a/src/Scopes/Classic/PublishedFlagScope.php
+++ b/src/Scopes/Classic/PublishedFlagScope.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Scopes\Classic;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/**
+ * Class PublishedFlagScope.
+ *
+ * @package Cog\Flag\Scopes\Classic
+ */
+class PublishedFlagScope implements Scope
+{
+    /**
+     * All of the extensions to be added to the builder.
+     *
+     * @var array
+     */
+    protected $extensions = ['Publish', 'Unpublish', 'WithUnpublished', 'WithoutUnpublished', 'OnlyUnpublished'];
+
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        return $builder->where('is_published', 1);
+    }
+
+    /**
+     * Extend the query builder with the needed functions.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    public function extend(Builder $builder)
+    {
+        foreach ($this->extensions as $extension) {
+            $this->{"add{$extension}"}($builder);
+        }
+    }
+
+    /**
+     * Add the `publish` extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    protected function addPublish(Builder $builder)
+    {
+        $builder->macro('publish', function (Builder $builder) {
+            $builder->withUnpublished();
+
+            return $builder->update(['is_published' => 1]);
+        });
+    }
+
+    /**
+     * Add the `unpublish` extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    protected function addUnpublish(Builder $builder)
+    {
+        $builder->macro('unpublish', function (Builder $builder) {
+            return $builder->update(['is_published' => 0]);
+        });
+    }
+
+    /**
+     * Add the `withUnpublished` extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    protected function addWithUnpublished(Builder $builder)
+    {
+        $builder->macro('withUnpublished', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this);
+        });
+    }
+
+    /**
+     * Add the `withoutUnpublished` extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    protected function addWithoutUnpublished(Builder $builder)
+    {
+        $builder->macro('withoutUnpublished', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_published', 1);
+        });
+    }
+
+    /**
+     * Add the `onlyUnpublished` extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    protected function addOnlyUnpublished(Builder $builder)
+    {
+        $builder->macro('onlyUnpublished', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_published', 0);
+        });
+    }
+}

--- a/src/Scopes/Classic/VerifiedFlagScope.php
+++ b/src/Scopes/Classic/VerifiedFlagScope.php
@@ -9,25 +9,25 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Scopes;
+namespace Cog\Flag\Scopes\Classic;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Class AcceptedFlagScope.
+ * Class VerifiedFlagScope.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Scopes\Classic
  */
-class AcceptedFlagScope implements Scope
+class VerifiedFlagScope implements Scope
 {
     /**
      * All of the extensions to be added to the builder.
      *
      * @var array
      */
-    protected $extensions = ['Accept', 'Unaccept', 'WithUnaccepted', 'WithoutUnaccepted', 'OnlyUnaccepted'];
+    protected $extensions = ['Verify', 'Unverify', 'WithUnverified', 'WithoutUnverified', 'OnlyUnverified'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -38,7 +38,7 @@ class AcceptedFlagScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        return $builder->where('is_accepted', 1);
+        return $builder->where('is_verified', 1);
     }
 
     /**
@@ -55,69 +55,69 @@ class AcceptedFlagScope implements Scope
     }
 
     /**
-     * Add the `accept` extension to the builder.
+     * Add the `verify` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addAccept(Builder $builder)
+    protected function addVerify(Builder $builder)
     {
-        $builder->macro('accept', function (Builder $builder) {
-            $builder->withUnaccepted();
+        $builder->macro('verify', function (Builder $builder) {
+            $builder->withUnverified();
 
-            return $builder->update(['is_accepted' => 1]);
+            return $builder->update(['is_verified' => 1]);
         });
     }
 
     /**
-     * Add the `unaccept` extension to the builder.
+     * Add the `unverify` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addUnaccept(Builder $builder)
+    protected function addUnverify(Builder $builder)
     {
-        $builder->macro('unaccept', function (Builder $builder) {
-            return $builder->update(['is_accepted' => 0]);
+        $builder->macro('unverify', function (Builder $builder) {
+            return $builder->update(['is_verified' => 0]);
         });
     }
 
     /**
-     * Add the `withUnaccepted` extension to the builder.
+     * Add the `withUnverified` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithUnaccepted(Builder $builder)
+    protected function addWithUnverified(Builder $builder)
     {
-        $builder->macro('withUnaccepted', function (Builder $builder) {
+        $builder->macro('withUnverified', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutUnaccepted` extension to the builder.
+     * Add the `withoutUnverified` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutUnaccepted(Builder $builder)
+    protected function addWithoutUnverified(Builder $builder)
     {
-        $builder->macro('withoutUnaccepted', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_accepted', 1);
+        $builder->macro('withoutUnverified', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_verified', 1);
         });
     }
 
     /**
-     * Add the `onlyUnaccepted` extension to the builder.
+     * Add the `onlyUnverified` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyUnaccepted(Builder $builder)
+    protected function addOnlyUnverified(Builder $builder)
     {
-        $builder->macro('onlyUnaccepted', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_accepted', 0);
+        $builder->macro('onlyUnverified', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_verified', 0);
         });
     }
 }

--- a/src/Scopes/Inverse/ExpiredFlagScope.php
+++ b/src/Scopes/Inverse/ExpiredFlagScope.php
@@ -9,25 +9,25 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Scopes;
+namespace Cog\Flag\Scopes\Inverse;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Class VerifiedFlagScope.
+ * Class ExpiredFlagScope.
  *
- * @package Cog\Flag\Scopes
+ * @package Cog\Flag\Scopes\Inverse
  */
-class VerifiedFlagScope implements Scope
+class ExpiredFlagScope implements Scope
 {
     /**
      * All of the extensions to be added to the builder.
      *
      * @var array
      */
-    protected $extensions = ['Verify', 'Unverify', 'WithUnverified', 'WithoutUnverified', 'OnlyUnverified'];
+    protected $extensions = ['Unexpire', 'Expire', 'WithExpired', 'WithoutExpired', 'OnlyExpired'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -38,7 +38,7 @@ class VerifiedFlagScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        return $builder->where('is_verified', 1);
+        return $builder->where('is_expired', 0);
     }
 
     /**
@@ -55,69 +55,69 @@ class VerifiedFlagScope implements Scope
     }
 
     /**
-     * Add the `verify` extension to the builder.
+     * Add the `unexpire` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addVerify(Builder $builder)
+    protected function addUnexpire(Builder $builder)
     {
-        $builder->macro('verify', function (Builder $builder) {
-            $builder->withUnverified();
+        $builder->macro('unexpire', function (Builder $builder) {
+            $builder->withExpired();
 
-            return $builder->update(['is_verified' => 1]);
+            return $builder->update(['is_expired' => 0]);
         });
     }
 
     /**
-     * Add the `unverify` extension to the builder.
+     * Add the `expire` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addUnverify(Builder $builder)
+    protected function addExpire(Builder $builder)
     {
-        $builder->macro('unverify', function (Builder $builder) {
-            return $builder->update(['is_verified' => 0]);
+        $builder->macro('expire', function (Builder $builder) {
+            return $builder->update(['is_expired' => 1]);
         });
     }
 
     /**
-     * Add the `withUnverified` extension to the builder.
+     * Add the `withExpired` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithUnverified(Builder $builder)
+    protected function addWithExpired(Builder $builder)
     {
-        $builder->macro('withUnverified', function (Builder $builder) {
+        $builder->macro('withExpired', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutUnverified` extension to the builder.
+     * Add the `withoutExpired` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutUnverified(Builder $builder)
+    protected function addWithoutExpired(Builder $builder)
     {
-        $builder->macro('withoutUnverified', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_verified', 1);
+        $builder->macro('withoutExpired', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_expired', 0);
         });
     }
 
     /**
-     * Add the `onlyUnverified` extension to the builder.
+     * Add the `onlyExpired` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyUnverified(Builder $builder)
+    protected function addOnlyExpired(Builder $builder)
     {
-        $builder->macro('onlyUnverified', function (Builder $builder) {
-            return $builder->withoutGlobalScope($this)->where('is_verified', 0);
+        $builder->macro('onlyExpired', function (Builder $builder) {
+            return $builder->withoutGlobalScope($this)->where('is_expired', 1);
         });
     }
 }

--- a/src/Traits/Classic/HasAcceptedFlag.php
+++ b/src/Traits/Classic/HasAcceptedFlag.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits;
+namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\AcceptedFlagScope;
+use Cog\Flag\Scopes\Classic\AcceptedFlagScope;
 
 /**
  * Class HasAcceptedFlag.
  *
- * @package Cog\Flag\Traits
+ * @package Cog\Flag\Traits\Classic
  */
 trait HasAcceptedFlag
 {

--- a/src/Traits/Classic/HasActiveFlag.php
+++ b/src/Traits/Classic/HasActiveFlag.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits;
+namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\ActiveFlagScope;
+use Cog\Flag\Scopes\Classic\ActiveFlagScope;
 
 /**
  * Class HasActiveFlag.
  *
- * @package Cog\Flag\Traits
+ * @package Cog\Flag\Traits\Classic
  */
 trait HasActiveFlag
 {

--- a/src/Traits/Classic/HasApprovedFlag.php
+++ b/src/Traits/Classic/HasApprovedFlag.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits;
+namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\ApprovedFlagScope;
+use Cog\Flag\Scopes\Classic\ApprovedFlagScope;
 
 /**
  * Class HasApprovedFlag.
  *
- * @package Cog\Flag\Traits
+ * @package Cog\Flag\Traits\Classic
  */
 trait HasApprovedFlag
 {

--- a/src/Traits/Classic/HasKeptFlag.php
+++ b/src/Traits/Classic/HasKeptFlag.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits;
+namespace Cog\Flag\Traits\Classic;
 
 use Carbon\Carbon;
-use Cog\Flag\Scopes\KeptFlagScope;
+use Cog\Flag\Scopes\Classic\KeptFlagScope;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class HasKeptFlag.
  *
- * @package Cog\Flag\Traits
+ * @package Cog\Flag\Traits\Classic
  */
 trait HasKeptFlag
 {

--- a/src/Traits/Classic/HasPublishedFlag.php
+++ b/src/Traits/Classic/HasPublishedFlag.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits;
+namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\PublishedFlagScope;
+use Cog\Flag\Scopes\Classic\PublishedFlagScope;
 
 /**
  * Class HasPublishedFlag.
  *
- * @package Cog\Flag\Traits
+ * @package Cog\Flag\Traits\Classic
  */
 trait HasPublishedFlag
 {

--- a/src/Traits/Classic/HasVerifiedFlag.php
+++ b/src/Traits/Classic/HasVerifiedFlag.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits;
+namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\VerifiedFlagScope;
+use Cog\Flag\Scopes\Classic\VerifiedFlagScope;
 
 /**
  * Class HasVerifiedFlag.
  *
- * @package Cog\Flag\Traits
+ * @package Cog\Flag\Traits\Classic
  */
 trait HasVerifiedFlag
 {

--- a/src/Traits/Inverse/HasExpiredFlag.php
+++ b/src/Traits/Inverse/HasExpiredFlag.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Inverse;
+
+use Cog\Flag\Scopes\Inverse\ExpiredFlagScope;
+
+/**
+ * Class HasExpiredFlag.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasExpiredFlag
+{
+    /**
+     * Boot the HasExpiredFlag trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasExpiredFlag()
+    {
+        static::addGlobalScope(new ExpiredFlagScope);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Flag\Tests;
 
-use Illuminate\Support\Facades\File;
 use Cog\Flag\Providers\FlagServiceProvider;
+use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 /**

--- a/tests/database/factories/EntityWithAcceptedFlagFactory.php
+++ b/tests/database/factories/EntityWithAcceptedFlagFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-$factory->define(\Cog\Flag\Tests\Stubs\Models\EntityWithAcceptedFlag::class, function (\Faker\Generator $faker) {
+$factory->define(\Cog\Flag\Tests\Stubs\Models\Classic\EntityWithAcceptedFlag::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
         'is_accepted' => true,

--- a/tests/database/factories/EntityWithActiveFlagFactory.php
+++ b/tests/database/factories/EntityWithActiveFlagFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-$factory->define(\Cog\Flag\Tests\Stubs\Models\EntityWithActiveFlag::class, function (\Faker\Generator $faker) {
+$factory->define(\Cog\Flag\Tests\Stubs\Models\Classic\EntityWithActiveFlag::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
         'is_active' => true,

--- a/tests/database/factories/EntityWithApprovedFlagFactory.php
+++ b/tests/database/factories/EntityWithApprovedFlagFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-$factory->define(\Cog\Flag\Tests\Stubs\Models\EntityWithApprovedFlag::class, function (\Faker\Generator $faker) {
+$factory->define(\Cog\Flag\Tests\Stubs\Models\Classic\EntityWithApprovedFlag::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
         'is_approved' => true,

--- a/tests/database/factories/EntityWithExpiredFlagFactory.php
+++ b/tests/database/factories/EntityWithExpiredFlagFactory.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-$factory->define(\Cog\Flag\Tests\Stubs\Models\Classic\EntityWithVerifiedFlag::class, function (\Faker\Generator $faker) {
+$factory->define(\Cog\Flag\Tests\Stubs\Models\Inverse\EntityWithExpiredFlag::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
-        'is_verified' => true,
+        'is_expired' => false,
     ];
 });

--- a/tests/database/factories/EntityWithKeptFlagFactory.php
+++ b/tests/database/factories/EntityWithKeptFlagFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-$factory->define(\Cog\Flag\Tests\Stubs\Models\EntityWithKeptFlag::class, function (\Faker\Generator $faker) {
+$factory->define(\Cog\Flag\Tests\Stubs\Models\Classic\EntityWithKeptFlag::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
         'is_kept' => false,

--- a/tests/database/factories/EntityWithPublishedFlagFactory.php
+++ b/tests/database/factories/EntityWithPublishedFlagFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-$factory->define(\Cog\Flag\Tests\Stubs\Models\EntityWithPublishedFlag::class, function (\Faker\Generator $faker) {
+$factory->define(\Cog\Flag\Tests\Stubs\Models\Classic\EntityWithPublishedFlag::class, function (\Faker\Generator $faker) {
     return [
         'name' => $faker->word,
         'is_published' => true,

--- a/tests/database/migrations/2016_09_25_182750_create_entity_with_expired_flag_table.php
+++ b/tests/database/migrations/2016_09_25_182750_create_entity_with_expired_flag_table.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Class CreateEntityWithExpiredFlagTable.
+ */
+class CreateEntityWithExpiredFlagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('entity_with_expired_flag', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('is_expired');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('entity_with_expired_flag');
+    }
+}

--- a/tests/stubs/Models/Classic/EntityWithAcceptedFlag.php
+++ b/tests/stubs/Models/Classic/EntityWithAcceptedFlag.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Stubs\Models;
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
 
-use Cog\Flag\Traits\HasAcceptedFlag;
+use Cog\Flag\Traits\Classic\HasAcceptedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class EntityWithAcceptedFlag.
  *
- * @package Cog\Flag\Tests\Stubs\Models
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
  */
 class EntityWithAcceptedFlag extends Model
 {

--- a/tests/stubs/Models/Classic/EntityWithActiveFlag.php
+++ b/tests/stubs/Models/Classic/EntityWithActiveFlag.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
+
+use Cog\Flag\Traits\Classic\HasActiveFlag;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class EntityWithActiveFlag.
+ *
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
+ */
+class EntityWithActiveFlag extends Model
+{
+    use HasActiveFlag;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'entity_with_active_flag';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'is_active' => 'bool',
+    ];
+}

--- a/tests/stubs/Models/Classic/EntityWithApprovedFlag.php
+++ b/tests/stubs/Models/Classic/EntityWithApprovedFlag.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Stubs\Models;
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
 
-use Cog\Flag\Traits\HasApprovedFlag;
+use Cog\Flag\Traits\Classic\HasApprovedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class EntityWithApprovedFlag.
  *
- * @package Cog\Flag\Tests\Stubs\Models
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
  */
 class EntityWithApprovedFlag extends Model
 {

--- a/tests/stubs/Models/Classic/EntityWithKeptFlag.php
+++ b/tests/stubs/Models/Classic/EntityWithKeptFlag.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Stubs\Models;
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
 
-use Cog\Flag\Traits\HasKeptFlag;
+use Cog\Flag\Traits\Classic\HasKeptFlag;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class EntityWithKeptFlag.
  *
- * @package Cog\Flag\Tests\Stubs\Models
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
  */
 class EntityWithKeptFlag extends Model
 {

--- a/tests/stubs/Models/Classic/EntityWithPublishedFlag.php
+++ b/tests/stubs/Models/Classic/EntityWithPublishedFlag.php
@@ -9,26 +9,26 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Stubs\Models;
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
 
-use Cog\Flag\Traits\HasVerifiedFlag;
+use Cog\Flag\Traits\Classic\HasPublishedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Class EntityWithVerifiedFlag.
+ * Class EntityWithPublishedFlag.
  *
- * @package Cog\Flag\Tests\Stubs\Models
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
  */
-class EntityWithVerifiedFlag extends Model
+class EntityWithPublishedFlag extends Model
 {
-    use HasVerifiedFlag;
+    use HasPublishedFlag;
 
     /**
      * The table associated with the model.
      *
      * @var string
      */
-    protected $table = 'entity_with_verified_flag';
+    protected $table = 'entity_with_published_flag';
 
     /**
      * The attributes that are mass assignable.
@@ -45,6 +45,6 @@ class EntityWithVerifiedFlag extends Model
      * @var array
      */
     protected $casts = [
-        'is_verified' => 'bool',
+        'is_published' => 'bool',
     ];
 }

--- a/tests/stubs/Models/Classic/EntityWithVerifiedFlag.php
+++ b/tests/stubs/Models/Classic/EntityWithVerifiedFlag.php
@@ -9,26 +9,26 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Stubs\Models;
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
 
-use Cog\Flag\Traits\HasActiveFlag;
+use Cog\Flag\Traits\Classic\HasVerifiedFlag;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Class EntityWithActiveFlag.
+ * Class EntityWithVerifiedFlag.
  *
- * @package Cog\Flag\Tests\Stubs\Models
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
  */
-class EntityWithActiveFlag extends Model
+class EntityWithVerifiedFlag extends Model
 {
-    use HasActiveFlag;
+    use HasVerifiedFlag;
 
     /**
      * The table associated with the model.
      *
      * @var string
      */
-    protected $table = 'entity_with_active_flag';
+    protected $table = 'entity_with_verified_flag';
 
     /**
      * The attributes that are mass assignable.
@@ -45,6 +45,6 @@ class EntityWithActiveFlag extends Model
      * @var array
      */
     protected $casts = [
-        'is_active' => 'bool',
+        'is_verified' => 'bool',
     ];
 }

--- a/tests/stubs/Models/Inverse/EntityWithExpiredFlag.php
+++ b/tests/stubs/Models/Inverse/EntityWithExpiredFlag.php
@@ -9,26 +9,26 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Stubs\Models;
+namespace Cog\Flag\Tests\Stubs\Models\Inverse;
 
-use Cog\Flag\Traits\HasPublishedFlag;
+use Cog\Flag\Traits\Inverse\HasExpiredFlag;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Class EntityWithPublishedFlag.
+ * Class EntityWithExpiredFlag.
  *
- * @package Cog\Flag\Tests\Stubs\Models
+ * @package Cog\Flag\Tests\Stubs\Models\Inverse
  */
-class EntityWithPublishedFlag extends Model
+class EntityWithExpiredFlag extends Model
 {
-    use HasPublishedFlag;
+    use HasExpiredFlag;
 
     /**
      * The table associated with the model.
      *
      * @var string
      */
-    protected $table = 'entity_with_published_flag';
+    protected $table = 'entity_with_expired_flag';
 
     /**
      * The attributes that are mass assignable.
@@ -45,6 +45,6 @@ class EntityWithPublishedFlag extends Model
      * @var array
      */
     protected $casts = [
-        'is_published' => 'bool',
+        'is_expired' => 'bool',
     ];
 }

--- a/tests/unit/Scopes/Classic/AcceptedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/AcceptedFlagScopeTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Scopes;
+namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithAcceptedFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithAcceptedFlag;
 
 /**
  * Class AcceptedFlagScopeTest.
  *
- * @package Cog\Flag\Tests\Unit\Scopes
+ * @package Cog\Flag\Tests\Unit\Scopes\Classic
  */
 class AcceptedFlagScopeTest extends TestCase
 {

--- a/tests/unit/Scopes/Classic/ActiveFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/ActiveFlagScopeTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Scopes;
+namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithActiveFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithActiveFlag;
 
 /**
  * Class ActiveFlagScopeTest.
  *
- * @package Cog\Flag\Tests\Unit\Scopes
+ * @package Cog\Flag\Tests\Unit\Scopes\Classic
  */
 class ActiveFlagScopeTest extends TestCase
 {

--- a/tests/unit/Scopes/Classic/ApprovedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/ApprovedFlagScopeTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Scopes;
+namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithApprovedFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithApprovedFlag;
 
 /**
  * Class ApprovedFlagScopeTest.
  *
- * @package Cog\Flag\Tests\Unit\Scopes
+ * @package Cog\Flag\Tests\Unit\Scopes\Classic
  */
 class ApprovedFlagScopeTest extends TestCase
 {

--- a/tests/unit/Scopes/Classic/KeptFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/KeptFlagScopeTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Scopes;
+namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithKeptFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithKeptFlag;
 
 /**
  * Class KeptFlagScopeTest.
  *
- * @package Cog\Flag\Tests\Unit\Scopes
+ * @package Cog\Flag\Tests\Unit\Scopes\Classic
  */
 class KeptFlagScopeTest extends TestCase
 {

--- a/tests/unit/Scopes/Classic/PublishedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/PublishedFlagScopeTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Scopes;
+namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithPublishedFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithPublishedFlag;
 
 /**
  * Class PublishedFlagScopeTest.
  *
- * @package Cog\Flag\Tests\Unit\Scopes
+ * @package Cog\Flag\Tests\Unit\Scopes\Classic
  */
 class PublishedFlagScopeTest extends TestCase
 {

--- a/tests/unit/Scopes/Classic/VerifiedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/VerifiedFlagScopeTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Scopes;
+namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithVerifiedFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithVerifiedFlag;
 
 /**
  * Class VerifiedFlagScopeTest.
  *
- * @package Cog\Flag\Tests\Unit\Scopes
+ * @package Cog\Flag\Tests\Unit\Scopes\Classic
  */
 class VerifiedFlagScopeTest extends TestCase
 {

--- a/tests/unit/Scopes/Inverse/ExpiredFlagScopeTest.php
+++ b/tests/unit/Scopes/Inverse/ExpiredFlagScopeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Unit\Scopes\Inverse;
+
+use Cog\Flag\Tests\Stubs\Models\Inverse\EntityWithExpiredFlag;
+use Cog\Flag\Tests\TestCase;
+
+/**
+ * Class ExpiredFlagScopeTest.
+ *
+ * @package Cog\Flag\Tests\Unit\Scopes\Inverse
+ */
+class ExpiredFlagScopeTest extends TestCase
+{
+    /** @test */
+    public function it_can_get_only_not_expired()
+    {
+        factory(EntityWithExpiredFlag::class, 2)->create([
+            'is_expired' => true,
+        ]);
+        factory(EntityWithExpiredFlag::class, 3)->create([
+            'is_expired' => false,
+        ]);
+
+        $entities = EntityWithExpiredFlag::all();
+
+        $this->assertCount(3, $entities);
+    }
+
+    /** @test */
+    public function it_can_get_without_expired()
+    {
+        factory(EntityWithExpiredFlag::class, 2)->create([
+            'is_expired' => true,
+        ]);
+        factory(EntityWithExpiredFlag::class, 3)->create([
+            'is_expired' => false,
+        ]);
+
+        $entities = EntityWithExpiredFlag::withoutExpired()->get();
+
+        $this->assertCount(3, $entities);
+    }
+
+    /** @test */
+    public function it_can_get_with_expired()
+    {
+        factory(EntityWithExpiredFlag::class, 2)->create([
+            'is_expired' => true,
+        ]);
+        factory(EntityWithExpiredFlag::class, 3)->create([
+            'is_expired' => false,
+        ]);
+
+        $entities = EntityWithExpiredFlag::withExpired()->get();
+
+        $this->assertCount(5, $entities);
+    }
+
+    /** @test */
+    public function it_can_get_only_expired()
+    {
+        factory(EntityWithExpiredFlag::class, 2)->create([
+            'is_expired' => true,
+        ]);
+        factory(EntityWithExpiredFlag::class, 3)->create([
+            'is_expired' => false,
+        ]);
+
+        $entities = EntityWithExpiredFlag::onlyExpired()->get();
+
+        $this->assertCount(2, $entities);
+    }
+
+    /** @test */
+    public function it_can_unexpire_model()
+    {
+        $model = factory(EntityWithExpiredFlag::class)->create([
+            'is_expired' => true,
+        ]);
+
+        EntityWithExpiredFlag::where('id', $model->id)->unexpire();
+
+        $model = EntityWithExpiredFlag::where('id', $model->id)->first();
+
+        $this->assertFalse($model->is_expired);
+    }
+
+    /** @test */
+    public function it_can_expire_model()
+    {
+        $model = factory(EntityWithExpiredFlag::class)->create([
+            'is_expired' => false,
+        ]);
+
+        EntityWithExpiredFlag::where('id', $model->id)->expire();
+
+        $model = EntityWithExpiredFlag::withExpired()->where('id', $model->id)->first();
+
+        $this->assertTrue($model->is_expired);
+    }
+}

--- a/tests/unit/Traits/Classic/HasKeptFlagTest.php
+++ b/tests/unit/Traits/Classic/HasKeptFlagTest.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Tests\Unit\Traits;
+namespace Cog\Flag\Tests\Unit\Traits\Classic;
 
 use Carbon\Carbon;
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithKeptFlag;
 use Cog\Flag\Tests\TestCase;
-use Cog\Flag\Tests\Stubs\Models\EntityWithKeptFlag;
 
 /**
  * Class HasKeptFlagTest.
  *
- * @package Cog\Flag\Tests\Unit\Traits
+ * @package Cog\Flag\Tests\Unit\Traits\Classic
  */
 class HasKeptFlagTest extends TestCase
 {


### PR DESCRIPTION
The new logical `Inverse` group added. All flags from `1.x` version moved to `Classic` logical group.

**How to upgrade**
- Find all `use Cog\Flag\Traits;` in your controllers.
- Replace with `use Cog\Flag\Traits\Classic;`

## 2.0.0 - 2016-01-04

#### Breaking changes

- Namespaces of flag's traits received `Classic` at the end: `Cog\Flag\Traits\Classic`.
- Namespaces of flag's scopes received `Classic` at the end: `Cog\Flag\Scopes\Classic`.

#### Added

- `Inverse Logic` flags group. Hides entities if flag not set.
- `is_expired` inverse boolean flag added.