### PR TITLE
Separate flag scopes & helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
+## 3.0.0 - [Unreleased]
+
+### Added
+
+- `Has{Name}FlagScope` traits which include global scopes.
+- `Has{Name}FlagHelpers` traits which include flag related helper methods.
+- `Has{Name}FlagBehavior` traits which include flag specific behavior.
+
+### Changed
+
+- Each Flag trait was spliced on 2 additional traits: `Has{Name}Flag` = `Has{Name}FlagScope` + `Has{Name}FlagHelpers`
+- Kept Flag trait was spliced on 3 additional traits, because events were pulled out to `HasKeptFlagBehavior` trait.
+
 ## 2.1.0 - 2016-01-04
 
 - `is_closed` inverse boolean flag added.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cybercog/laravel-eloquent-flag",
-    "description": "Laravel Eloquent flagged attributes behavior",
+    "description": "Laravel Eloquent flagged attributes behavior.",
     "type": "library",
     "license": "MIT",
     "keywords": [
@@ -50,14 +50,14 @@
         "docs": "https://github.com/cybercog/laravel-eloquent-flag/wiki"
     },
     "require": {
-        "php": "^5.6|^7.0",
-        "illuminate/database": "~5.2.0|~5.3.0|~5.4.0"
+        "illuminate/database": "~5.2.0|~5.3.0|~5.4.0",
+        "php": "^5.6|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",
-        "phpunit/phpunit": "^5.2",
+        "mockery/mockery": "^0.9.5",
         "orchestra/testbench": "~3.0",
-        "mockery/mockery": "^0.9.5"
+        "phpunit/phpunit": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Traits/Classic/HasAcceptedFlag.php
+++ b/src/Traits/Classic/HasAcceptedFlag.php
@@ -11,8 +11,6 @@
 
 namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\Classic\AcceptedFlagScope;
-
 /**
  * Class HasAcceptedFlag.
  *
@@ -20,13 +18,5 @@ use Cog\Flag\Scopes\Classic\AcceptedFlagScope;
  */
 trait HasAcceptedFlag
 {
-    /**
-     * Boot the HasAcceptedFlag trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasAcceptedFlag()
-    {
-        static::addGlobalScope(new AcceptedFlagScope);
-    }
+    use HasAcceptedFlagScope;
 }

--- a/src/Traits/Classic/HasAcceptedFlagHelpers.php
+++ b/src/Traits/Classic/HasAcceptedFlagHelpers.php
@@ -12,12 +12,11 @@
 namespace Cog\Flag\Traits\Classic;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasAcceptedFlagHelpers.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasAcceptedFlag
+trait HasAcceptedFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Classic/HasAcceptedFlagScope.php
+++ b/src/Traits/Classic/HasAcceptedFlagScope.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Classic;
+
+use Cog\Flag\Scopes\Classic\AcceptedFlagScope;
+
+/**
+ * Class HasAcceptedFlagScope.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasAcceptedFlagScope
+{
+    /**
+     * Boot the HasAcceptedFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasAcceptedFlagScope()
+    {
+        static::addGlobalScope(new AcceptedFlagScope);
+    }
+}

--- a/src/Traits/Classic/HasActiveFlag.php
+++ b/src/Traits/Classic/HasActiveFlag.php
@@ -18,5 +18,6 @@ namespace Cog\Flag\Traits\Classic;
  */
 trait HasActiveFlag
 {
-    use HasActiveFlagScope;
+    use HasActiveFlagHelpers,
+        HasActiveFlagScope;
 }

--- a/src/Traits/Classic/HasActiveFlag.php
+++ b/src/Traits/Classic/HasActiveFlag.php
@@ -11,8 +11,6 @@
 
 namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\Classic\ActiveFlagScope;
-
 /**
  * Class HasActiveFlag.
  *
@@ -20,13 +18,5 @@ use Cog\Flag\Scopes\Classic\ActiveFlagScope;
  */
 trait HasActiveFlag
 {
-    /**
-     * Boot the HasKeptFlag trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasActiveFlag()
-    {
-        static::addGlobalScope(new ActiveFlagScope);
-    }
+    use HasActiveFlagScope;
 }

--- a/src/Traits/Classic/HasActiveFlagHelpers.php
+++ b/src/Traits/Classic/HasActiveFlagHelpers.php
@@ -12,12 +12,11 @@
 namespace Cog\Flag\Traits\Classic;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasActiveFlagHelpers.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasAcceptedFlag
+trait HasActiveFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Classic/HasActiveFlagScope.php
+++ b/src/Traits/Classic/HasActiveFlagScope.php
@@ -11,12 +11,22 @@
 
 namespace Cog\Flag\Traits\Classic;
 
+use Cog\Flag\Scopes\Classic\ActiveFlagScope;
+
 /**
- * Class HasVerifiedFlag.
+ * Class HasActiveFlagScope.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasVerifiedFlag
+trait HasActiveFlagScope
 {
-    use HasVerifiedFlagScope;
+    /**
+     * Boot the HasKeptFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasActiveFlagScope()
+    {
+        static::addGlobalScope(new ActiveFlagScope);
+    }
 }

--- a/src/Traits/Classic/HasApprovedFlag.php
+++ b/src/Traits/Classic/HasApprovedFlag.php
@@ -18,5 +18,6 @@ namespace Cog\Flag\Traits\Classic;
  */
 trait HasApprovedFlag
 {
-    use HasApprovedFlagScope;
+    use HasApprovedFlagHelpers,
+        HasApprovedFlagScope;
 }

--- a/src/Traits/Classic/HasApprovedFlag.php
+++ b/src/Traits/Classic/HasApprovedFlag.php
@@ -11,8 +11,6 @@
 
 namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\Classic\ApprovedFlagScope;
-
 /**
  * Class HasApprovedFlag.
  *
@@ -20,13 +18,5 @@ use Cog\Flag\Scopes\Classic\ApprovedFlagScope;
  */
 trait HasApprovedFlag
 {
-    /**
-     * Boot the HasApprovedFlag trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasApprovedFlag()
-    {
-        static::addGlobalScope(new ApprovedFlagScope);
-    }
+    use HasApprovedFlagScope;
 }

--- a/src/Traits/Classic/HasApprovedFlagHelpers.php
+++ b/src/Traits/Classic/HasApprovedFlagHelpers.php
@@ -12,12 +12,11 @@
 namespace Cog\Flag\Traits\Classic;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasApprovedFlagHelpers.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasAcceptedFlag
+trait HasApprovedFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Classic/HasApprovedFlagScope.php
+++ b/src/Traits/Classic/HasApprovedFlagScope.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Classic;
+
+use Cog\Flag\Scopes\Classic\ApprovedFlagScope;
+
+/**
+ * Class HasApprovedFlagScope.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasApprovedFlagScope
+{
+    /**
+     * Boot the HasApprovedFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasApprovedFlagScope()
+    {
+        static::addGlobalScope(new ApprovedFlagScope);
+    }
+}

--- a/src/Traits/Classic/HasKeptFlag.php
+++ b/src/Traits/Classic/HasKeptFlag.php
@@ -11,9 +11,6 @@
 
 namespace Cog\Flag\Traits\Classic;
 
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Builder;
-
 /**
  * Class HasKeptFlag.
  *
@@ -21,48 +18,7 @@ use Illuminate\Database\Eloquent\Builder;
  */
 trait HasKeptFlag
 {
-    use HasKeptFlagScope;
-
-    /**
-     * Boot the HasKeptFlag trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasKeptFlag()
-    {
-        static::creating(function ($entity) {
-            if (!$entity->is_kept) {
-                $entity->is_kept = false;
-            }
-        });
-
-        static::updating(function ($entity) {
-            if (!$entity->is_kept) {
-                $entity->is_kept = true;
-            }
-        });
-    }
-
-    /**
-     * Determine if the model instance has `is_kept` state.
-     *
-     * @return bool
-     */
-    public function isKept()
-    {
-        return (bool) $this->is_kept;
-    }
-
-    /**
-     * Get unkept models that are older than the given number of hours.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $builder
-     * @param int $hours
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeOnlyUnkeptOlderThanHours(Builder $builder, $hours)
-    {
-        return $builder->onlyUnkept()
-            ->where(static::getCreatedAtColumn(), '<=', Carbon::now()->subHours($hours)->toDateTimeString());
-    }
+    use HasKeptFlagBehavior,
+        HasKeptFlagHelpers,
+        HasKeptFlagScope;
 }

--- a/src/Traits/Classic/HasKeptFlag.php
+++ b/src/Traits/Classic/HasKeptFlag.php
@@ -12,7 +12,6 @@
 namespace Cog\Flag\Traits\Classic;
 
 use Carbon\Carbon;
-use Cog\Flag\Scopes\Classic\KeptFlagScope;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -22,6 +21,8 @@ use Illuminate\Database\Eloquent\Builder;
  */
 trait HasKeptFlag
 {
+    use HasKeptFlagScope;
+
     /**
      * Boot the HasKeptFlag trait for a model.
      *
@@ -29,8 +30,6 @@ trait HasKeptFlag
      */
     public static function bootHasKeptFlag()
     {
-        static::addGlobalScope(new KeptFlagScope);
-
         static::creating(function ($entity) {
             if (!$entity->is_kept) {
                 $entity->is_kept = false;

--- a/src/Traits/Classic/HasKeptFlagBehavior.php
+++ b/src/Traits/Classic/HasKeptFlagBehavior.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Classic;
+
+/**
+ * Class HasKeptFlagBehavior.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasKeptFlagBehavior
+{
+    /**
+     * Boot the bootHasKeptFlagBehavior trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasKeptFlagBehavior()
+    {
+        static::creating(function ($entity) {
+            if (!$entity->is_kept) {
+                $entity->is_kept = false;
+            }
+        });
+
+        static::updating(function ($entity) {
+            if (!$entity->is_kept) {
+                $entity->is_kept = true;
+            }
+        });
+    }
+}

--- a/src/Traits/Classic/HasKeptFlagHelpers.php
+++ b/src/Traits/Classic/HasKeptFlagHelpers.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Classic;
+
+use Carbon\Carbon;
+use Cog\Flag\Scopes\Classic\KeptFlagScope;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Class HasKeptFlagHelpers.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasKeptFlagHelpers
+{
+    /**
+     * Determine if the model instance has `is_kept` state.
+     *
+     * @return bool
+     */
+    public function isKept()
+    {
+        return (bool) $this->is_kept;
+    }
+
+    /**
+     * Get unkept models that are older than the given number of hours.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param int $hours
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOnlyUnkeptOlderThanHours(Builder $builder, $hours)
+    {
+        return $builder
+            ->withoutGlobalScope(KeptFlagScope::class)
+            ->where('is_kept', 0)
+            ->where(static::getCreatedAtColumn(), '<=', Carbon::now()->subHours($hours)->toDateTimeString());
+    }
+}

--- a/src/Traits/Classic/HasKeptFlagScope.php
+++ b/src/Traits/Classic/HasKeptFlagScope.php
@@ -11,12 +11,22 @@
 
 namespace Cog\Flag\Traits\Classic;
 
+use Cog\Flag\Scopes\Classic\KeptFlagScope;
+
 /**
- * Class HasVerifiedFlag.
+ * Class HasKeptFlagScope.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasVerifiedFlag
+trait HasKeptFlagScope
 {
-    use HasVerifiedFlagScope;
+    /**
+     * Boot the HasKeptFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasKeptFlagScope()
+    {
+        static::addGlobalScope(new KeptFlagScope);
+    }
 }

--- a/src/Traits/Classic/HasPublishedFlag.php
+++ b/src/Traits/Classic/HasPublishedFlag.php
@@ -18,5 +18,6 @@ namespace Cog\Flag\Traits\Classic;
  */
 trait HasPublishedFlag
 {
-    use HasPublishedFlagScope;
+    use HasPublishedFlagHelpers,
+        HasPublishedFlagScope;
 }

--- a/src/Traits/Classic/HasPublishedFlag.php
+++ b/src/Traits/Classic/HasPublishedFlag.php
@@ -11,8 +11,6 @@
 
 namespace Cog\Flag\Traits\Classic;
 
-use Cog\Flag\Scopes\Classic\PublishedFlagScope;
-
 /**
  * Class HasPublishedFlag.
  *
@@ -20,13 +18,5 @@ use Cog\Flag\Scopes\Classic\PublishedFlagScope;
  */
 trait HasPublishedFlag
 {
-    /**
-     * Boot the HasPublishedFlag trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasPublishedFlag()
-    {
-        static::addGlobalScope(new PublishedFlagScope);
-    }
+    use HasPublishedFlagScope;
 }

--- a/src/Traits/Classic/HasPublishedFlagHelpers.php
+++ b/src/Traits/Classic/HasPublishedFlagHelpers.php
@@ -12,12 +12,11 @@
 namespace Cog\Flag\Traits\Classic;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasPublishedFlagHelpers.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasAcceptedFlag
+trait HasPublishedFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Classic/HasPublishedFlagScope.php
+++ b/src/Traits/Classic/HasPublishedFlagScope.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Classic;
+
+use Cog\Flag\Scopes\Classic\PublishedFlagScope;
+
+/**
+ * Class HasPublishedFlagScope.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasPublishedFlagScope
+{
+    /**
+     * Boot the HasPublishedFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasPublishedFlagScope()
+    {
+        static::addGlobalScope(new PublishedFlagScope);
+    }
+}

--- a/src/Traits/Classic/HasVerifiedFlag.php
+++ b/src/Traits/Classic/HasVerifiedFlag.php
@@ -18,5 +18,6 @@ namespace Cog\Flag\Traits\Classic;
  */
 trait HasVerifiedFlag
 {
-    use HasVerifiedFlagScope;
+    use HasVerifiedFlagHelpers,
+        HasVerifiedFlagScope;
 }

--- a/src/Traits/Classic/HasVerifiedFlagHelpers.php
+++ b/src/Traits/Classic/HasVerifiedFlagHelpers.php
@@ -12,12 +12,11 @@
 namespace Cog\Flag\Traits\Classic;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasVerifiedFlagHelpers.
  *
  * @package Cog\Flag\Traits\Classic
  */
-trait HasAcceptedFlag
+trait HasVerifiedFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Classic/HasVerifiedFlagScope.php
+++ b/src/Traits/Classic/HasVerifiedFlagScope.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Traits\Classic;
+
+use Cog\Flag\Scopes\Classic\VerifiedFlagScope;
+
+/**
+ * Class HasVerifiedFlagScope.
+ *
+ * @package Cog\Flag\Traits\Classic
+ */
+trait HasVerifiedFlagScope
+{
+    /**
+     * Boot the HasVerifiedTraitScope for a model.
+     *
+     * @return void
+     */
+    public static function bootHasVerifiedFlagScope()
+    {
+        static::addGlobalScope(new VerifiedFlagScope);
+    }
+}

--- a/src/Traits/Inverse/HasClosedFlag.php
+++ b/src/Traits/Inverse/HasClosedFlag.php
@@ -18,5 +18,6 @@ namespace Cog\Flag\Traits\Inverse;
  */
 trait HasClosedFlag
 {
-    use HasClosedFlagScope;
+    use HasClosedFlagHelpers,
+        HasClosedFlagScope;
 }

--- a/src/Traits/Inverse/HasClosedFlagHelpers.php
+++ b/src/Traits/Inverse/HasClosedFlagHelpers.php
@@ -9,15 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits\Classic;
+namespace Cog\Flag\Traits\Inverse;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasClosedFlagHelpers.
  *
- * @package Cog\Flag\Traits\Classic
+ * @package Cog\Flag\Traits\Inverse
  */
-trait HasAcceptedFlag
+trait HasClosedFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Inverse/HasClosedFlagScope.php
+++ b/src/Traits/Inverse/HasClosedFlagScope.php
@@ -11,12 +11,22 @@
 
 namespace Cog\Flag\Traits\Inverse;
 
+use Cog\Flag\Scopes\Inverse\ClosedFlagScope;
+
 /**
- * Class HasClosedFlag.
+ * Class HasClosedFlagScope.
  *
  * @package Cog\Flag\Traits\Inverse
  */
-trait HasClosedFlag
+trait HasClosedFlagScope
 {
-    use HasClosedFlagScope;
+    /**
+     * Boot the HasClosedFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasClosedFlagScope()
+    {
+        static::addGlobalScope(new ClosedFlagScope);
+    }
 }

--- a/src/Traits/Inverse/HasExpiredFlag.php
+++ b/src/Traits/Inverse/HasExpiredFlag.php
@@ -11,8 +11,6 @@
 
 namespace Cog\Flag\Traits\Inverse;
 
-use Cog\Flag\Scopes\Inverse\ExpiredFlagScope;
-
 /**
  * Class HasExpiredFlag.
  *
@@ -20,13 +18,5 @@ use Cog\Flag\Scopes\Inverse\ExpiredFlagScope;
  */
 trait HasExpiredFlag
 {
-    /**
-     * Boot the HasExpiredFlag trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasExpiredFlag()
-    {
-        static::addGlobalScope(new ExpiredFlagScope);
-    }
+    use HasExpiredFlagScope;
 }

--- a/src/Traits/Inverse/HasExpiredFlag.php
+++ b/src/Traits/Inverse/HasExpiredFlag.php
@@ -18,5 +18,6 @@ namespace Cog\Flag\Traits\Inverse;
  */
 trait HasExpiredFlag
 {
-    use HasExpiredFlagScope;
+    use HasExpiredFlagHelpers,
+        HasExpiredFlagScope;
 }

--- a/src/Traits/Inverse/HasExpiredFlagHelpers.php
+++ b/src/Traits/Inverse/HasExpiredFlagHelpers.php
@@ -9,15 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Cog\Flag\Traits\Classic;
+namespace Cog\Flag\Traits\Inverse;
 
 /**
- * Class HasAcceptedFlag.
+ * Class HasExpiredFlagHelpers.
  *
- * @package Cog\Flag\Traits\Classic
+ * @package Cog\Flag\Traits\Inverse
  */
-trait HasAcceptedFlag
+trait HasExpiredFlagHelpers
 {
-    use HasAcceptedFlagHelpers,
-        HasAcceptedFlagScope;
+    //
 }

--- a/src/Traits/Inverse/HasExpiredFlagScope.php
+++ b/src/Traits/Inverse/HasExpiredFlagScope.php
@@ -11,12 +11,22 @@
 
 namespace Cog\Flag\Traits\Inverse;
 
+use Cog\Flag\Scopes\Inverse\ExpiredFlagScope;
+
 /**
- * Class HasClosedFlag.
+ * Class HasExpiredFlagScope.
  *
  * @package Cog\Flag\Traits\Inverse
  */
-trait HasClosedFlag
+trait HasExpiredFlagScope
 {
-    use HasClosedFlagScope;
+    /**
+     * Boot the HasExpiredFlagScope trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasExpiredFlagScope()
+    {
+        static::addGlobalScope(new ExpiredFlagScope);
+    }
 }

--- a/tests/unit/Traits/Classic/HasKeptFlagBehaviorTest.php
+++ b/tests/unit/Traits/Classic/HasKeptFlagBehaviorTest.php
@@ -11,16 +11,15 @@
 
 namespace Cog\Flag\Tests\Unit\Traits\Classic;
 
-use Carbon\Carbon;
 use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithKeptFlag;
 use Cog\Flag\Tests\TestCase;
 
 /**
- * Class HasKeptFlagTest.
+ * Class HasKeptFlagBehaviorTest.
  *
  * @package Cog\Flag\Tests\Unit\Traits\Classic
  */
-class HasKeptFlagTest extends TestCase
+class HasKeptFlagBehaviorTest extends TestCase
 {
     /** @test */
     public function it_sets_is_kept_false_on_create()
@@ -45,28 +44,5 @@ class HasKeptFlagTest extends TestCase
         ]);
 
         $this->assertTrue($entity->is_kept);
-    }
-
-    /** @test */
-    public function it_can_get_unkept_older_than_hours()
-    {
-        factory(EntityWithKeptFlag::class, 3)->create([
-            'is_kept' => true,
-        ]);
-        factory(EntityWithKeptFlag::class, 2)->create([
-            'is_kept' => false,
-            'created_at' => Carbon::now()->subHours(4)->toDateTimeString(),
-        ]);
-        factory(EntityWithKeptFlag::class, 2)->create([
-            'is_kept' => false,
-            'created_at' => Carbon::now()->subHours(2)->toDateTimeString(),
-        ]);
-        factory(EntityWithKeptFlag::class, 2)->create([
-            'is_kept' => false,
-        ]);
-
-        $entities = EntityWithKeptFlag::onlyUnkeptOlderThanHours(4)->get();
-
-        $this->assertCount(2, $entities);
     }
 }

--- a/tests/unit/Traits/Classic/HasKeptFlagHelperTest.php
+++ b/tests/unit/Traits/Classic/HasKeptFlagHelperTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Unit\Traits\Classic;
+
+use Carbon\Carbon;
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithKeptFlag;
+use Cog\Flag\Tests\TestCase;
+
+/**
+ * Class HasKeptFlagHelperTest.
+ *
+ * @package Cog\Flag\Tests\Unit\Traits\Classic
+ */
+class HasKeptFlagHelperTest extends TestCase
+{
+    /** @test */
+    public function it_can_check_if_entity_is_kept()
+    {
+        $entity = factory(EntityWithKeptFlag::class, 1)->create([
+            'is_kept' => true,
+        ]);
+
+        $this->assertTrue($entity->isKept());
+    }
+
+    /** @test */
+    public function it_can_get_unkept_older_than_hours()
+    {
+        factory(EntityWithKeptFlag::class, 3)->create([
+            'is_kept' => true,
+            'created_at' => Carbon::now()->subHours(4)->toDateTimeString(),
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+            'created_at' => Carbon::now()->subHours(4)->toDateTimeString(),
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+            'created_at' => Carbon::now()->subHours(2)->toDateTimeString(),
+        ]);
+        factory(EntityWithKeptFlag::class, 2)->create([
+            'is_kept' => false,
+        ]);
+
+        $entities = EntityWithKeptFlag::onlyUnkeptOlderThanHours(4)->get();
+
+        $this->assertCount(2, $entities);
+    }
+}


### PR DESCRIPTION
Each flag has root trait `Has{Name}Flag` which will use:
- `Has{Name}FlagScope` adds global scopes to flag (and global scope related methods).
- `Has{Name}FlagHelpers` for additional flag methods.
- `Has{Name}FlagBehavior` - used only in Kept flag to implement it's default behavior (model will be created with `is_kept=false` and will change to `is_kept=true` on first model update).