### PR TITLE
Follow approved naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
 ### Changed
 
-- Each Flag trait was spliced on 2 additional traits: `Has{Name}Flag` = `Has{Name}FlagScope` + `Has{Name}FlagHelpers`
+- Each Flag trait was spliced on 2 additional traits: `Has{Name}Flag` = `Has{Name}FlagScope` + `Has{Name}FlagHelpers`.
 - Kept Flag trait was spliced on 3 additional traits, because events were pulled out to `HasKeptFlagBehavior` trait.
+- Flags `Classic\Accepted`, `Classic\Active` & `Classic\Approved` methods were changed. Details in the [UPGRADING.md](UPGRADING.md).
 
 ## 2.1.0 - 2016-01-04
 

--- a/README.md
+++ b/README.md
@@ -84,19 +84,19 @@ class Post extends Model
 
 ```php
 Post::all();
-Post::withoutInactive();
+Post::withoutDeactivated();
 ```
 
-#### Get only inactive models
+#### Get only deactivated models
 
 ```php
-Post::onlyInactive();
+Post::onlyDeactivated();
 ```
 
-#### Get active + inactive models
+#### Get active + deactivated models
 
 ```php
-Post::withInactive();
+Post::withDeactivated();
 ```
 
 #### Activate model
@@ -135,19 +135,19 @@ class Post extends Model
 
 ```php
 Post::all();
-Post::withoutUnaccepted();
+Post::withoutRejected();
 ```
 
-#### Get only unaccepted models
+#### Get only rejected models
 
 ```php
-Post::onlyUnaccepted();
+Post::onlyRejected();
 ```
 
-#### Get accepted + unaccepted models
+#### Get accepted + rejected models
 
 ```php
-Post::withUnaccepted();
+Post::withRejected();
 ```
 
 #### Accept model
@@ -159,7 +159,7 @@ Post::where('id', 4)->accept();
 #### Deactivate model
 
 ```php
-Post::where('id', 4)->unaccept();
+Post::where('id', 4)->reject();
 ```
 
 ### Setup an approvable model
@@ -186,19 +186,19 @@ class Post extends Model
 
 ```php
 Post::all();
-Post::withoutUnapproved();
+Post::withoutDisapproved();
 ```
 
-#### Get only unapproved models
+#### Get only disapproved models
 
 ```php
-Post::onlyUnapproved();
+Post::onlyDisapproved();
 ```
 
-#### Get approved + unapproved models
+#### Get approved + disapproved models
 
 ```php
-Post::withUnapproved();
+Post::withDisapproved();
 ```
 
 #### Approve model
@@ -207,10 +207,10 @@ Post::withUnapproved();
 Post::where('id', 4)->approve();
 ```
 
-#### Unapprove model
+#### Disapprove model
 
 ```php
-Post::where('id', 4)->unapprove();
+Post::where('id', 4)->disapprove();
 ```
 
 ### Setup a publishable model

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,24 @@
+# Upgrading
+
+## From v2 to v3
+
+You can upgrade from v2 to v3 by performing these renames in your model that has flags: `Accepted`, `Active` & `Approved`.
+
+These methods should be renamed:
+
+- `unaccept()` has been renamed to `reject()`.
+- `withUnaccepted()` has been renamed to `withRejected()`.
+- `withoutUnaccepted()` has been renamed to `withoutRejected()`.
+- `onlyUnaccepted()` has been renamed to `onlyRejected()`.
+- `withInactive()` has been renamed to `withDeactivated()`.
+- `withoutInactive()` has been renamed to `withoutDeactivated()`.
+- `onlyInactive()` has been renamed to `onlyDeactivated()`.
+- `unapprove()` has been renamed to `disapprove()`.
+- `withUnapproved()` has been renamed to `withDisapproved()`.
+- `withoutUnapproved()` has been renamed to `withoutDisapproved()`.
+- `onlyUnapproved()` has been renamed to `onlyDisapproved()`.
+
+## From v1 to v2
+
+- Namespaces of flag's traits received `Classic` at the end: `Cog\Flag\Traits\Classic`.
+- Namespaces of flag's scopes received `Classic` at the end: `Cog\Flag\Scopes\Classic`.

--- a/src/Scopes/Classic/AcceptedFlagScope.php
+++ b/src/Scopes/Classic/AcceptedFlagScope.php
@@ -27,7 +27,7 @@ class AcceptedFlagScope implements Scope
      *
      * @var array
      */
-    protected $extensions = ['Accept', 'Unaccept', 'WithUnaccepted', 'WithoutUnaccepted', 'OnlyUnaccepted'];
+    protected $extensions = ['Accept', 'Reject', 'WithRejected', 'WithoutRejected', 'OnlyRejected'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -63,60 +63,60 @@ class AcceptedFlagScope implements Scope
     protected function addAccept(Builder $builder)
     {
         $builder->macro('accept', function (Builder $builder) {
-            $builder->withUnaccepted();
+            $builder->withRejected();
 
             return $builder->update(['is_accepted' => 1]);
         });
     }
 
     /**
-     * Add the `unaccept` extension to the builder.
+     * Add the `reject` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addUnaccept(Builder $builder)
+    protected function addReject(Builder $builder)
     {
-        $builder->macro('unaccept', function (Builder $builder) {
+        $builder->macro('reject', function (Builder $builder) {
             return $builder->update(['is_accepted' => 0]);
         });
     }
 
     /**
-     * Add the `withUnaccepted` extension to the builder.
+     * Add the `withRejected` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithUnaccepted(Builder $builder)
+    protected function addWithRejected(Builder $builder)
     {
-        $builder->macro('withUnaccepted', function (Builder $builder) {
+        $builder->macro('withRejected', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutUnaccepted` extension to the builder.
+     * Add the `withoutRejected` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutUnaccepted(Builder $builder)
+    protected function addWithoutRejected(Builder $builder)
     {
-        $builder->macro('withoutUnaccepted', function (Builder $builder) {
+        $builder->macro('withoutRejected', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->where('is_accepted', 1);
         });
     }
 
     /**
-     * Add the `onlyUnaccepted` extension to the builder.
+     * Add the `onlyRejected` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyUnaccepted(Builder $builder)
+    protected function addOnlyRejected(Builder $builder)
     {
-        $builder->macro('onlyUnaccepted', function (Builder $builder) {
+        $builder->macro('onlyRejected', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->where('is_accepted', 0);
         });
     }

--- a/src/Scopes/Classic/ActiveFlagScope.php
+++ b/src/Scopes/Classic/ActiveFlagScope.php
@@ -27,7 +27,7 @@ class ActiveFlagScope implements Scope
      *
      * @var array
      */
-    protected $extensions = ['Activate', 'Deactivate', 'WithInactive', 'WithoutInactive', 'OnlyInactive'];
+    protected $extensions = ['Activate', 'Deactivate', 'WithDeactivated', 'WithoutDeactivated', 'OnlyDeactivated'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -63,7 +63,7 @@ class ActiveFlagScope implements Scope
     protected function addActivate(Builder $builder)
     {
         $builder->macro('activate', function (Builder $builder) {
-            $builder->withInactive();
+            $builder->withDeactivated();
 
             return $builder->update(['is_active' => 1]);
         });
@@ -83,40 +83,40 @@ class ActiveFlagScope implements Scope
     }
 
     /**
-     * Add the `withInactive` extension to the builder.
+     * Add the `withDeactivated` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithInactive(Builder $builder)
+    protected function addWithDeactivated(Builder $builder)
     {
-        $builder->macro('withInactive', function (Builder $builder) {
+        $builder->macro('withDeactivated', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutInactive` extension to the builder.
+     * Add the `withoutDeactivated` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutInactive(Builder $builder)
+    protected function addWithoutDeactivated(Builder $builder)
     {
-        $builder->macro('withoutInactive', function (Builder $builder) {
+        $builder->macro('withoutDeactivated', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->where('is_active', 1);
         });
     }
 
     /**
-     * Add the `onlyInactive` extension to the builder.
+     * Add the `onlyDeactivated` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyInactive(Builder $builder)
+    protected function addOnlyDeactivated(Builder $builder)
     {
-        $builder->macro('onlyInactive', function (Builder $builder) {
+        $builder->macro('onlyDeactivated', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->where('is_active', 0);
         });
     }

--- a/src/Scopes/Classic/ApprovedFlagScope.php
+++ b/src/Scopes/Classic/ApprovedFlagScope.php
@@ -27,7 +27,7 @@ class ApprovedFlagScope implements Scope
      *
      * @var array
      */
-    protected $extensions = ['Approve', 'Unapprove', 'WithUnapproved', 'WithoutUnapproved', 'OnlyUnapproved'];
+    protected $extensions = ['Approve', 'Disapprove', 'WithDisapproved', 'WithoutDisapproved', 'OnlyDisapproved'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -63,60 +63,60 @@ class ApprovedFlagScope implements Scope
     protected function addApprove(Builder $builder)
     {
         $builder->macro('approve', function (Builder $builder) {
-            $builder->withUnapproved();
+            $builder->withDisapproved();
 
             return $builder->update(['is_approved' => 1]);
         });
     }
 
     /**
-     * Add the `unapprove` extension to the builder.
+     * Add the `disapprove` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addUnapprove(Builder $builder)
+    protected function addDisapprove(Builder $builder)
     {
-        $builder->macro('unapprove', function (Builder $builder) {
+        $builder->macro('disapprove', function (Builder $builder) {
             return $builder->update(['is_approved' => 0]);
         });
     }
 
     /**
-     * Add the `withUnapproved` extension to the builder.
+     * Add the `withDisapproved` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithUnapproved(Builder $builder)
+    protected function addWithDisapproved(Builder $builder)
     {
-        $builder->macro('withUnapproved', function (Builder $builder) {
+        $builder->macro('withDisapproved', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
         });
     }
 
     /**
-     * Add the `withoutUnapproved` extension to the builder.
+     * Add the `withoutDisapproved` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutUnapproved(Builder $builder)
+    protected function addWithoutDisapproved(Builder $builder)
     {
-        $builder->macro('withoutUnapproved', function (Builder $builder) {
+        $builder->macro('withoutDisapproved', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->where('is_approved', 1);
         });
     }
 
     /**
-     * Add the `onlyUnapproved` extension to the builder.
+     * Add the `onlyDisapproved` extension to the builder.
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyUnapproved(Builder $builder)
+    protected function addOnlyDisapproved(Builder $builder)
     {
-        $builder->macro('onlyUnapproved', function (Builder $builder) {
+        $builder->macro('onlyDisapproved', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->where('is_approved', 0);
         });
     }

--- a/tests/unit/Scopes/Classic/AcceptedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/AcceptedFlagScopeTest.php
@@ -37,7 +37,7 @@ class AcceptedFlagScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_without_unaccepted()
+    public function it_can_get_without_rejected()
     {
         factory(EntityWithAcceptedFlag::class, 3)->create([
             'is_accepted' => true,
@@ -46,13 +46,13 @@ class AcceptedFlagScopeTest extends TestCase
             'is_accepted' => false,
         ]);
 
-        $entities = EntityWithAcceptedFlag::withoutUnaccepted()->get();
+        $entities = EntityWithAcceptedFlag::withoutRejected()->get();
 
         $this->assertCount(3, $entities);
     }
 
     /** @test */
-    public function it_can_get_with_unaccepted()
+    public function it_can_get_with_rejected()
     {
         factory(EntityWithAcceptedFlag::class, 3)->create([
             'is_accepted' => true,
@@ -61,13 +61,13 @@ class AcceptedFlagScopeTest extends TestCase
             'is_accepted' => false,
         ]);
 
-        $entities = EntityWithAcceptedFlag::withUnaccepted()->get();
+        $entities = EntityWithAcceptedFlag::withRejected()->get();
 
         $this->assertCount(5, $entities);
     }
 
     /** @test */
-    public function it_can_get_only_unaccepted()
+    public function it_can_get_only_rejected()
     {
         factory(EntityWithAcceptedFlag::class, 3)->create([
             'is_accepted' => true,
@@ -76,7 +76,7 @@ class AcceptedFlagScopeTest extends TestCase
             'is_accepted' => false,
         ]);
 
-        $entities = EntityWithAcceptedFlag::onlyUnaccepted()->get();
+        $entities = EntityWithAcceptedFlag::onlyRejected()->get();
 
         $this->assertCount(2, $entities);
     }
@@ -102,9 +102,9 @@ class AcceptedFlagScopeTest extends TestCase
             'is_accepted' => true,
         ]);
 
-        EntityWithAcceptedFlag::where('id', $model->id)->unaccept();
+        EntityWithAcceptedFlag::where('id', $model->id)->reject();
 
-        $model = EntityWithAcceptedFlag::withUnaccepted()->where('id', $model->id)->first();
+        $model = EntityWithAcceptedFlag::withRejected()->where('id', $model->id)->first();
 
         $this->assertFalse($model->is_accepted);
     }

--- a/tests/unit/Scopes/Classic/ActiveFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/ActiveFlagScopeTest.php
@@ -37,7 +37,7 @@ class ActiveFlagScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_without_inactive()
+    public function it_can_get_without_deactivated()
     {
         factory(EntityWithActiveFlag::class, 3)->create([
             'is_active' => true,
@@ -46,13 +46,13 @@ class ActiveFlagScopeTest extends TestCase
             'is_active' => false,
         ]);
 
-        $entities = EntityWithActiveFlag::withoutInactive()->get();
+        $entities = EntityWithActiveFlag::withoutDeactivated()->get();
 
         $this->assertCount(3, $entities);
     }
 
     /** @test */
-    public function it_can_get_with_inactive()
+    public function it_can_get_with_deactivated()
     {
         factory(EntityWithActiveFlag::class, 3)->create([
             'is_active' => true,
@@ -61,13 +61,13 @@ class ActiveFlagScopeTest extends TestCase
             'is_active' => false,
         ]);
 
-        $entities = EntityWithActiveFlag::withInactive()->get();
+        $entities = EntityWithActiveFlag::withDeactivated()->get();
 
         $this->assertCount(5, $entities);
     }
 
     /** @test */
-    public function it_can_get_only_inactive()
+    public function it_can_get_only_deactivated()
     {
         factory(EntityWithActiveFlag::class, 3)->create([
             'is_active' => true,
@@ -76,7 +76,7 @@ class ActiveFlagScopeTest extends TestCase
             'is_active' => false,
         ]);
 
-        $entities = EntityWithActiveFlag::onlyInactive()->get();
+        $entities = EntityWithActiveFlag::onlyDeactivated()->get();
 
         $this->assertCount(2, $entities);
     }
@@ -104,7 +104,7 @@ class ActiveFlagScopeTest extends TestCase
 
         EntityWithActiveFlag::where('id', $model->id)->deactivate();
 
-        $model = EntityWithActiveFlag::withInactive()->where('id', $model->id)->first();
+        $model = EntityWithActiveFlag::withDeactivated()->where('id', $model->id)->first();
 
         $this->assertFalse($model->is_active);
     }

--- a/tests/unit/Scopes/Classic/ApprovedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/ApprovedFlagScopeTest.php
@@ -37,7 +37,7 @@ class ApprovedFlagScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_without_unapproved()
+    public function it_can_get_without_disapproved()
     {
         factory(EntityWithApprovedFlag::class, 3)->create([
             'is_approved' => true,
@@ -46,13 +46,13 @@ class ApprovedFlagScopeTest extends TestCase
             'is_approved' => false,
         ]);
 
-        $entities = EntityWithApprovedFlag::withoutUnapproved()->get();
+        $entities = EntityWithApprovedFlag::withoutDisapproved()->get();
 
         $this->assertCount(3, $entities);
     }
 
     /** @test */
-    public function it_can_get_with_unapproved()
+    public function it_can_get_with_disapproved()
     {
         factory(EntityWithApprovedFlag::class, 3)->create([
             'is_approved' => true,
@@ -61,13 +61,13 @@ class ApprovedFlagScopeTest extends TestCase
             'is_approved' => false,
         ]);
 
-        $entities = EntityWithApprovedFlag::withUnapproved()->get();
+        $entities = EntityWithApprovedFlag::withDisapproved()->get();
 
         $this->assertCount(5, $entities);
     }
 
     /** @test */
-    public function it_can_get_only_unapproved()
+    public function it_can_get_only_disapproved()
     {
         factory(EntityWithApprovedFlag::class, 3)->create([
             'is_approved' => true,
@@ -76,7 +76,7 @@ class ApprovedFlagScopeTest extends TestCase
             'is_approved' => false,
         ]);
 
-        $entities = EntityWithApprovedFlag::onlyUnapproved()->get();
+        $entities = EntityWithApprovedFlag::onlyDisapproved()->get();
 
         $this->assertCount(2, $entities);
     }
@@ -96,15 +96,15 @@ class ApprovedFlagScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_unapprove_model()
+    public function it_can_disapprove_model()
     {
         $model = factory(EntityWithApprovedFlag::class)->create([
             'is_approved' => true,
         ]);
 
-        EntityWithApprovedFlag::where('id', $model->id)->unapprove();
+        EntityWithApprovedFlag::where('id', $model->id)->disapprove();
 
-        $model = EntityWithApprovedFlag::withUnapproved()->where('id', $model->id)->first();
+        $model = EntityWithApprovedFlag::withDisapproved()->where('id', $model->id)->first();
 
         $this->assertFalse($model->is_approved);
     }


### PR DESCRIPTION
To follow [naming convention](https://github.com/cybercog/laravel-eloquent-flag/issues/11) these methods should be renamed:

- `unaccept()` to `reject()`
- `unapprove()` to `disapprove()`
- `withUnaccepted()` to `withRejected()`
- `withoutUnaccepted()` to `withoutRejected()`
- `onlyUnaccepted()` to `onlyRejected()`
- `withInactive()` to `withDeactivated()`
- `withoutInactive()` to `withoutDeactivated()`
- `onlyInactive()` to `onlyDeactivated()`
- `withUnapproved()` to `withDisapproved()`
- `withoutUnapproved()` to `withoutDisapproved()`
- `onlyUnapproved()` to `onlyDisapproved()`