### PR TITLE
Add ability to skip auto apply Expired flags scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
+## [3.9.0] - 2017-02-03
+
+### Added
+
+- `shouldApplyExpiredAtScope` & `shouldApplyExpiredFlagScope` methods to skip Expired flags global scope auto apply.
+
 ## [3.8.0] - 2017-01-29
 
 ### Added
@@ -127,6 +133,7 @@ All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
 - `is_active` boolean flag added.
 
+[3.9.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.8.0...3.9.0
 [3.8.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.7.0...3.8.0
 [3.7.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.6.0...3.7.0
 [3.6.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.5.0...3.6.0

--- a/src/Scopes/Inverse/ExpiredAtScope.php
+++ b/src/Scopes/Inverse/ExpiredAtScope.php
@@ -39,6 +39,10 @@ class ExpiredAtScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
+        if (method_exists($model, 'shouldApplyExpiredAtScope') && !$model->shouldApplyExpiredAtScope()) {
+            return $builder;
+        }
+
         return $builder->whereNull('expired_at');
     }
 

--- a/src/Scopes/Inverse/ExpiredFlagScope.php
+++ b/src/Scopes/Inverse/ExpiredFlagScope.php
@@ -38,6 +38,10 @@ class ExpiredFlagScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
+        if (method_exists($model, 'shouldApplyExpiredFlagScope') && !$model->shouldApplyExpiredFlagScope()) {
+            return $builder;
+        }
+
         return $builder->where('is_expired', 0);
     }
 

--- a/tests/stubs/Models/Inverse/EntityWithExpiredAtUnapplied.php
+++ b/tests/stubs/Models/Inverse/EntityWithExpiredAtUnapplied.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Stubs\Models\Inverse;
+
+/**
+ * Class EntityWithExpiredAtUnapplied.
+ *
+ * @package Cog\Flag\Tests\Stubs\Models\Inverse
+ */
+class EntityWithExpiredAtUnapplied extends EntityWithExpiredAt
+{
+    /**
+     * Determine if ExpiredAtScope should be applied by default.
+     *
+     * @return bool
+     */
+    public function shouldApplyExpiredAtScope()
+    {
+        return false;
+    }
+}

--- a/tests/stubs/Models/Inverse/EntityWithExpiredFlagUnapplied.php
+++ b/tests/stubs/Models/Inverse/EntityWithExpiredFlagUnapplied.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Stubs\Models\Inverse;
+
+/**
+ * Class EntityWithExpiredFlagUnapplied.
+ *
+ * @package Cog\Flag\Tests\Stubs\Models\Inverse
+ */
+class EntityWithExpiredFlagUnapplied extends EntityWithExpiredFlag
+{
+    /**
+     * Determine if ExpiredFlagScope should be applied by default.
+     *
+     * @return bool
+     */
+    public function shouldApplyExpiredFlagScope()
+    {
+        return false;
+    }
+}

--- a/tests/unit/Scopes/Inverse/ExpiredAtScopeTest.php
+++ b/tests/unit/Scopes/Inverse/ExpiredAtScopeTest.php
@@ -13,6 +13,7 @@ namespace Cog\Flag\Tests\Unit\Scopes\Inverse;
 
 use Carbon\Carbon;
 use Cog\Flag\Tests\Stubs\Models\Inverse\EntityWithExpiredAt;
+use Cog\Flag\Tests\Stubs\Models\Inverse\EntityWithExpiredAtUnapplied;
 use Cog\Flag\Tests\TestCase;
 
 /**
@@ -108,5 +109,20 @@ class ExpiredAtScopeTest extends TestCase
         $model = EntityWithExpiredAt::withExpired()->where('id', $model->id)->first();
 
         $this->assertNotNull($model->expired_at);
+    }
+
+    /** @test */
+    public function it_can_skip_apply()
+    {
+        factory(EntityWithExpiredAt::class, 3)->create([
+            'expired_at' => Carbon::now()->subDay(),
+        ]);
+        factory(EntityWithExpiredAt::class, 2)->create([
+            'expired_at' => null,
+        ]);
+
+        $entities = EntityWithExpiredAtUnapplied::all();
+
+        $this->assertCount(5, $entities);
     }
 }

--- a/tests/unit/Scopes/Inverse/ExpiredFlagScopeTest.php
+++ b/tests/unit/Scopes/Inverse/ExpiredFlagScopeTest.php
@@ -12,6 +12,7 @@
 namespace Cog\Flag\Tests\Unit\Scopes\Inverse;
 
 use Cog\Flag\Tests\Stubs\Models\Inverse\EntityWithExpiredFlag;
+use Cog\Flag\Tests\Stubs\Models\Inverse\EntityWithExpiredFlagUnapplied;
 use Cog\Flag\Tests\TestCase;
 
 /**
@@ -107,5 +108,20 @@ class ExpiredFlagScopeTest extends TestCase
         $model = EntityWithExpiredFlag::withExpired()->where('id', $model->id)->first();
 
         $this->assertTrue($model->is_expired);
+    }
+
+    /** @test */
+    public function it_can_skip_apply()
+    {
+        factory(EntityWithExpiredFlag::class, 3)->create([
+            'is_expired' => true,
+        ]);
+        factory(EntityWithExpiredFlag::class, 2)->create([
+            'is_expired' => false,
+        ]);
+
+        $entities = EntityWithExpiredFlagUnapplied::all();
+
+        $this->assertCount(5, $entities);
     }
 }


### PR DESCRIPTION
Add ability to skip auto apply global scope but without losing all scope methods functionality. `true` by default.