### PR TITLE
Add ability to skip auto apply Verified flags scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
+## [3.10.0] - 2017-02-13
+
+### Added
+
+- `shouldApplyVerifiedAtScope` & `shouldApplyVerifiedFlagScope` methods to skip Verified flags global scope auto apply.
+
 ## [3.9.0] - 2017-02-03
 
 ### Added
@@ -133,6 +139,7 @@ All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
 - `is_active` boolean flag added.
 
+[3.10.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.9.0...3.10.0
 [3.9.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.8.0...3.9.0
 [3.8.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.7.0...3.8.0
 [3.7.0]: https://github.com/cybercog/laravel-eloquent-flag/compare/3.6.0...3.7.0

--- a/src/Scopes/Classic/VerifiedAtScope.php
+++ b/src/Scopes/Classic/VerifiedAtScope.php
@@ -39,6 +39,10 @@ class VerifiedAtScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
+        if (method_exists($model, 'shouldApplyVerifiedAtScope') && !$model->shouldApplyVerifiedAtScope()) {
+            return $builder;
+        }
+
         return $builder->whereNotNull('verified_at');
     }
 

--- a/src/Scopes/Classic/VerifiedFlagScope.php
+++ b/src/Scopes/Classic/VerifiedFlagScope.php
@@ -38,6 +38,10 @@ class VerifiedFlagScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
+        if (method_exists($model, 'shouldApplyVerifiedFlagScope') && !$model->shouldApplyVerifiedFlagScope()) {
+            return $builder;
+        }
+
         return $builder->where('is_verified', 1);
     }
 

--- a/tests/stubs/Models/Classic/EntityWithVerifiedAtUnapplied.php
+++ b/tests/stubs/Models/Classic/EntityWithVerifiedAtUnapplied.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
+
+/**
+ * Class EntityWithVerifiedAtUnapplied.
+ *
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
+ */
+class EntityWithVerifiedAtUnapplied extends EntityWithVerifiedAt
+{
+    /**
+     * Determine if VerifiedAtScope should be applied by default.
+     *
+     * @return bool
+     */
+    public function shouldApplyVerifiedAtScope()
+    {
+        return false;
+    }
+}

--- a/tests/stubs/Models/Classic/EntityWithVerifiedFlagUnapplied.php
+++ b/tests/stubs/Models/Classic/EntityWithVerifiedFlagUnapplied.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Laravel Eloquent Flag.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Flag\Tests\Stubs\Models\Classic;
+
+/**
+ * Class EntityWithVerifiedFlagUnapplied.
+ *
+ * @package Cog\Flag\Tests\Stubs\Models\Classic
+ */
+class EntityWithVerifiedFlagUnapplied extends EntityWithVerifiedFlag
+{
+    /**
+     * Determine if VerifiedFlagScope should be applied by default.
+     *
+     * @return bool
+     */
+    public function shouldApplyVerifiedFlagScope()
+    {
+        return false;
+    }
+}

--- a/tests/unit/Scopes/Classic/VerifiedAtScopeTest.php
+++ b/tests/unit/Scopes/Classic/VerifiedAtScopeTest.php
@@ -13,6 +13,7 @@ namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
 use Carbon\Carbon;
 use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithVerifiedAt;
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithVerifiedAtUnapplied;
 use Cog\Flag\Tests\TestCase;
 
 /**
@@ -108,5 +109,20 @@ class VerifiedAtScopeTest extends TestCase
         $model = EntityWithVerifiedAt::withUnverified()->where('id', $model->id)->first();
 
         $this->assertNull($model->verified_at);
+    }
+
+    /** @test */
+    public function it_can_skip_apply()
+    {
+        factory(EntityWithVerifiedAt::class, 3)->create([
+            'verified_at' => Carbon::now()->subDay(),
+        ]);
+        factory(EntityWithVerifiedAt::class, 2)->create([
+            'verified_at' => null,
+        ]);
+
+        $entities = EntityWithVerifiedAtUnapplied::all();
+
+        $this->assertCount(5, $entities);
     }
 }

--- a/tests/unit/Scopes/Classic/VerifiedFlagScopeTest.php
+++ b/tests/unit/Scopes/Classic/VerifiedFlagScopeTest.php
@@ -12,6 +12,7 @@
 namespace Cog\Flag\Tests\Unit\Scopes\Classic;
 
 use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithVerifiedFlag;
+use Cog\Flag\Tests\Stubs\Models\Classic\EntityWithVerifiedFlagUnapplied;
 use Cog\Flag\Tests\TestCase;
 
 /**
@@ -107,5 +108,20 @@ class VerifiedFlagScopeTest extends TestCase
         $model = EntityWithVerifiedFlag::withUnverified()->where('id', $model->id)->first();
 
         $this->assertFalse($model->is_verified);
+    }
+
+    /** @test */
+    public function it_can_skip_apply()
+    {
+        factory(EntityWithVerifiedFlag::class, 3)->create([
+            'is_verified' => true,
+        ]);
+        factory(EntityWithVerifiedFlag::class, 2)->create([
+            'is_verified' => false,
+        ]);
+
+        $entities = EntityWithVerifiedFlagUnapplied::all();
+
+        $this->assertCount(5, $entities);
     }
 }


### PR DESCRIPTION
Add ability to skip auto apply global scope but without losing all scope methods functionality. `true` by default.