### PR TITLE
Remove attribute mutator helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to `laravel-eloquent-flag` will be documented in this file.
 
 - Dropped PHP 5.6, 7.0 support
 - Dropped Laravel 5.2, 5.3, 5.4, 5.5, 5.6, 5.7 support
+- Removed attribute mutator `set*` & `unset*` methods from all helper classes
 
 ## [4.0.0] - 2018-09-09
 

--- a/src/Traits/Classic/HasAcceptedAtHelpers.php
+++ b/src/Traits/Classic/HasAcceptedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasAcceptedAtHelpers
     }
 
     /**
-     * Set accepted flag.
-     *
-     * @return static
-     */
-    public function setAcceptedFlag()
-    {
-        $this->setAttribute('accepted_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset accepted flag.
-     *
-     * @return static
-     */
-    public function unsetAcceptedFlag()
-    {
-        $this->setAttribute('accepted_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is accepted.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasAcceptedAtHelpers
      */
     public function accept(): void
     {
-        $this->setAcceptedFlag()->save();
+        $this->setAttribute('accepted_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('accepted', false);
     }
@@ -85,7 +62,8 @@ trait HasAcceptedAtHelpers
      */
     public function reject(): void
     {
-        $this->unsetAcceptedFlag()->save();
+        $this->setAttribute('accepted_at', null);
+        $this->save();
 
         $this->fireModelEvent('rejected', false);
     }

--- a/src/Traits/Classic/HasAcceptedFlagHelpers.php
+++ b/src/Traits/Classic/HasAcceptedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasAcceptedFlagHelpers
     }
 
     /**
-     * Set accepted flag.
-     *
-     * @return static
-     */
-    public function setAcceptedFlag()
-    {
-        $this->setAttribute('is_accepted', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset accepted flag.
-     *
-     * @return static
-     */
-    public function unsetAcceptedFlag()
-    {
-        $this->setAttribute('is_accepted', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is accepted.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasAcceptedFlagHelpers
      */
     public function accept(): void
     {
-        $this->setAcceptedFlag()->save();
+        $this->setAttribute('is_accepted', true);
+        $this->save();
 
         $this->fireModelEvent('accepted', false);
     }
@@ -83,7 +60,8 @@ trait HasAcceptedFlagHelpers
      */
     public function reject(): void
     {
-        $this->unsetAcceptedFlag()->save();
+        $this->setAttribute('is_accepted', false);
+        $this->save();
 
         $this->fireModelEvent('rejected', false);
     }

--- a/src/Traits/Classic/HasActiveFlagHelpers.php
+++ b/src/Traits/Classic/HasActiveFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasActiveFlagHelpers
     }
 
     /**
-     * Set active flag.
-     *
-     * @return static
-     */
-    public function setActivatedFlag()
-    {
-        $this->setAttribute('is_active', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset active flag.
-     *
-     * @return static
-     */
-    public function unsetActivatedFlag()
-    {
-        $this->setAttribute('is_active', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is activated.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasActiveFlagHelpers
      */
     public function activate(): void
     {
-        $this->setActivatedFlag()->save();
+        $this->setAttribute('is_active', true);
+        $this->save();
 
         $this->fireModelEvent('activated', false);
     }
@@ -83,7 +60,8 @@ trait HasActiveFlagHelpers
      */
     public function deactivate(): void
     {
-        $this->unsetActivatedFlag()->save();
+        $this->save();
+        $this->setAttribute('is_active', false);
 
         $this->fireModelEvent('deactivated', false);
     }

--- a/src/Traits/Classic/HasApprovedAtHelpers.php
+++ b/src/Traits/Classic/HasApprovedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasApprovedAtHelpers
     }
 
     /**
-     * Set approved flag.
-     *
-     * @return static
-     */
-    public function setApprovedFlag()
-    {
-        $this->setAttribute('approved_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset approved flag.
-     *
-     * @return static
-     */
-    public function unsetApprovedFlag()
-    {
-        $this->setAttribute('approved_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is approved.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasApprovedAtHelpers
      */
     public function approve(): void
     {
-        $this->setApprovedFlag()->save();
+        $this->setAttribute('approved_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('approved', false);
     }
@@ -85,7 +62,8 @@ trait HasApprovedAtHelpers
      */
     public function disapprove(): void
     {
-        $this->unsetApprovedFlag()->save();
+        $this->setAttribute('approved_at', null);
+        $this->save();
 
         $this->fireModelEvent('disapproved', false);
     }

--- a/src/Traits/Classic/HasApprovedFlagHelpers.php
+++ b/src/Traits/Classic/HasApprovedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasApprovedFlagHelpers
     }
 
     /**
-     * Set approved flag.
-     *
-     * @return static
-     */
-    public function setApprovedFlag()
-    {
-        $this->setAttribute('is_approved', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset approved flag.
-     *
-     * @return static
-     */
-    public function unsetApprovedFlag()
-    {
-        $this->setAttribute('is_approved', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is approved.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasApprovedFlagHelpers
      */
     public function approve(): void
     {
-        $this->setApprovedFlag()->save();
+        $this->setAttribute('is_approved', true);
+        $this->save();
 
         $this->fireModelEvent('approved', false);
     }
@@ -83,7 +60,8 @@ trait HasApprovedFlagHelpers
      */
     public function disapprove(): void
     {
-        $this->unsetApprovedFlag()->save();
+        $this->setAttribute('is_approved', false);
+        $this->save();
 
         $this->fireModelEvent('disapproved', false);
     }

--- a/src/Traits/Classic/HasInvitedAtHelpers.php
+++ b/src/Traits/Classic/HasInvitedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasInvitedAtHelpers
     }
 
     /**
-     * Set invited flag.
-     *
-     * @return static
-     */
-    public function setInvitedFlag()
-    {
-        $this->setAttribute('invited_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset invited flag.
-     *
-     * @return static
-     */
-    public function unsetInvitedFlag()
-    {
-        $this->setAttribute('invited_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is invited.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasInvitedAtHelpers
      */
     public function invite(): void
     {
-        $this->setInvitedFlag()->save();
+        $this->setAttribute('invited_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('invited', false);
     }
@@ -85,7 +62,8 @@ trait HasInvitedAtHelpers
      */
     public function uninvite(): void
     {
-        $this->unsetInvitedFlag()->save();
+        $this->setAttribute('invited_at', null);
+        $this->save();
 
         $this->fireModelEvent('uninvited', false);
     }

--- a/src/Traits/Classic/HasInvitedFlagHelpers.php
+++ b/src/Traits/Classic/HasInvitedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasInvitedFlagHelpers
     }
 
     /**
-     * Set invited flag.
-     *
-     * @return static
-     */
-    public function setInvitedFlag()
-    {
-        $this->setAttribute('is_invited', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset invited flag.
-     *
-     * @return static
-     */
-    public function unsetInvitedFlag()
-    {
-        $this->setAttribute('is_invited', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is invited.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasInvitedFlagHelpers
      */
     public function invite(): void
     {
-        $this->setInvitedFlag()->save();
+        $this->setAttribute('is_invited', true);
+        $this->save();
 
         $this->fireModelEvent('invited', false);
     }
@@ -83,7 +60,8 @@ trait HasInvitedFlagHelpers
      */
     public function uninvite(): void
     {
-        $this->unsetInvitedFlag()->save();
+        $this->setAttribute('is_invited', false);
+        $this->save();
 
         $this->fireModelEvent('uninvited', false);
     }

--- a/src/Traits/Classic/HasKeptFlagHelpers.php
+++ b/src/Traits/Classic/HasKeptFlagHelpers.php
@@ -25,34 +25,6 @@ trait HasKeptFlagHelpers
     }
 
     /**
-     * Set kept flag.
-     *
-     * @return static
-     */
-    public function setKeptFlag()
-    {
-        $this->setAttribute('is_kept', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset kept flag.
-     *
-     * @return static
-     */
-    public function unsetKeptFlag()
-    {
-        $this->setAttribute('is_kept', false);
-
-        if (property_exists($this, 'setKeptOnUpdate')) {
-            $this->setKeptOnUpdate = false;
-        }
-
-        return $this;
-    }
-
-    /**
      * If entity is kept.
      *
      * @return bool
@@ -79,7 +51,8 @@ trait HasKeptFlagHelpers
      */
     public function keep(): void
     {
-        $this->setKeptFlag()->save();
+        $this->setAttribute('is_kept', true);
+        $this->save();
 
         $this->fireModelEvent('kept', false);
     }
@@ -91,7 +64,11 @@ trait HasKeptFlagHelpers
      */
     public function unkeep(): void
     {
-        $this->unsetKeptFlag()->save();
+        $this->setAttribute('is_kept', false);
+        if (property_exists($this, 'setKeptOnUpdate')) {
+            $this->setKeptOnUpdate = false;
+        }
+        $this->save();
 
         $this->fireModelEvent('unkept', false);
     }

--- a/src/Traits/Classic/HasPublishedAtHelpers.php
+++ b/src/Traits/Classic/HasPublishedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasPublishedAtHelpers
     }
 
     /**
-     * Set published flag.
-     *
-     * @return static
-     */
-    public function setPublishedFlag()
-    {
-        $this->setAttribute('published_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset published flag.
-     *
-     * @return static
-     */
-    public function unsetPublishedFlag()
-    {
-        $this->setAttribute('published_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is published.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasPublishedAtHelpers
      */
     public function publish(): void
     {
-        $this->setPublishedFlag()->save();
+        $this->setAttribute('published_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('published', false);
     }
@@ -85,7 +62,8 @@ trait HasPublishedAtHelpers
      */
     public function unpublish(): void
     {
-        $this->unsetPublishedFlag()->save();
+        $this->setAttribute('published_at', null);
+        $this->save();
 
         $this->fireModelEvent('unpublished', false);
     }

--- a/src/Traits/Classic/HasPublishedFlagHelpers.php
+++ b/src/Traits/Classic/HasPublishedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasPublishedFlagHelpers
     }
 
     /**
-     * Set published flag.
-     *
-     * @return static
-     */
-    public function setPublishedFlag()
-    {
-        $this->setAttribute('is_published', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset published flag.
-     *
-     * @return static
-     */
-    public function unsetPublishedFlag()
-    {
-        $this->setAttribute('is_published', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is published.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasPublishedFlagHelpers
      */
     public function publish(): void
     {
-        $this->setPublishedFlag()->save();
+        $this->setAttribute('is_published', true);
+        $this->save();
 
         $this->fireModelEvent('published', false);
     }
@@ -83,7 +60,8 @@ trait HasPublishedFlagHelpers
      */
     public function unpublish(): void
     {
-        $this->unsetPublishedFlag()->save();
+        $this->setAttribute('is_published', false);
+        $this->save();
 
         $this->fireModelEvent('unpublished', false);
     }

--- a/src/Traits/Classic/HasVerifiedAtHelpers.php
+++ b/src/Traits/Classic/HasVerifiedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasVerifiedAtHelpers
     }
 
     /**
-     * Set verified flag.
-     *
-     * @return static
-     */
-    public function setVerifiedFlag()
-    {
-        $this->setAttribute('verified_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset verified flag.
-     *
-     * @return static
-     */
-    public function unsetVerifiedFlag()
-    {
-        $this->setAttribute('verified_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is verified.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasVerifiedAtHelpers
      */
     public function verify(): void
     {
-        $this->setVerifiedFlag()->save();
+        $this->setAttribute('verified_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('verified', false);
     }
@@ -85,7 +62,8 @@ trait HasVerifiedAtHelpers
      */
     public function unverify(): void
     {
-        $this->unsetVerifiedFlag()->save();
+        $this->setAttribute('verified_at', null);
+        $this->save();
 
         $this->fireModelEvent('unverified', false);
     }

--- a/src/Traits/Classic/HasVerifiedFlagHelpers.php
+++ b/src/Traits/Classic/HasVerifiedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasVerifiedFlagHelpers
     }
 
     /**
-     * Set verified flag.
-     *
-     * @return static
-     */
-    public function setVerifiedFlag()
-    {
-        $this->setAttribute('is_verified', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset verified flag.
-     *
-     * @return static
-     */
-    public function unsetVerifiedFlag()
-    {
-        $this->setAttribute('is_verified', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is verified.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasVerifiedFlagHelpers
      */
     public function verify(): void
     {
-        $this->setVerifiedFlag()->save();
+        $this->setAttribute('is_verified', true);
+        $this->save();
 
         $this->fireModelEvent('verified', false);
     }
@@ -83,7 +60,8 @@ trait HasVerifiedFlagHelpers
      */
     public function unverify(): void
     {
-        $this->unsetVerifiedFlag()->save();
+        $this->setAttribute('is_verified', false);
+        $this->save();
 
         $this->fireModelEvent('unverified', false);
     }

--- a/src/Traits/Inverse/HasArchivedAtHelpers.php
+++ b/src/Traits/Inverse/HasArchivedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasArchivedAtHelpers
     }
 
     /**
-     * Set archived flag.
-     *
-     * @return static
-     */
-    public function setArchivedFlag()
-    {
-        $this->setAttribute('archived_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset archived flag.
-     *
-     * @return static
-     */
-    public function unsetArchivedFlag()
-    {
-        $this->setAttribute('archived_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is archived.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasArchivedAtHelpers
      */
     public function archive(): void
     {
-        $this->setArchivedFlag()->save();
+        $this->setAttribute('archived_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('archived', false);
     }
@@ -85,7 +62,8 @@ trait HasArchivedAtHelpers
      */
     public function unarchive(): void
     {
-        $this->unsetArchivedFlag()->save();
+        $this->setAttribute('archived_at', null);
+        $this->save();
 
         $this->fireModelEvent('unarchived', false);
     }

--- a/src/Traits/Inverse/HasArchivedFlagHelpers.php
+++ b/src/Traits/Inverse/HasArchivedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasArchivedFlagHelpers
     }
 
     /**
-     * Set archived flag.
-     *
-     * @return static
-     */
-    public function setArchivedFlag()
-    {
-        $this->setAttribute('is_archived', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset archived flag.
-     *
-     * @return static
-     */
-    public function unsetArchivedFlag()
-    {
-        $this->setAttribute('is_archived', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is archived.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasArchivedFlagHelpers
      */
     public function archive(): void
     {
-        $this->setArchivedFlag()->save();
+        $this->setAttribute('is_archived', true);
+        $this->save();
 
         $this->fireModelEvent('archived', false);
     }
@@ -83,7 +60,8 @@ trait HasArchivedFlagHelpers
      */
     public function unarchive(): void
     {
-        $this->unsetArchivedFlag()->save();
+        $this->setAttribute('is_archived', false);
+        $this->save();
 
         $this->fireModelEvent('unarchived', false);
     }

--- a/src/Traits/Inverse/HasClosedAtHelpers.php
+++ b/src/Traits/Inverse/HasClosedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasClosedAtHelpers
     }
 
     /**
-     * Set closed flag.
-     *
-     * @return static
-     */
-    public function setClosedFlag()
-    {
-        $this->setAttribute('closed_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset closed flag.
-     *
-     * @return static
-     */
-    public function unsetClosedFlag()
-    {
-        $this->setAttribute('closed_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is closed.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasClosedAtHelpers
      */
     public function close(): void
     {
-        $this->setClosedFlag()->save();
+        $this->setAttribute('closed_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('closed', false);
     }
@@ -85,7 +62,8 @@ trait HasClosedAtHelpers
      */
     public function open(): void
     {
-        $this->unsetClosedFlag()->save();
+        $this->setAttribute('closed_at', null);
+        $this->save();
 
         $this->fireModelEvent('opened', false);
     }

--- a/src/Traits/Inverse/HasClosedFlagHelpers.php
+++ b/src/Traits/Inverse/HasClosedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasClosedFlagHelpers
     }
 
     /**
-     * Set closed flag.
-     *
-     * @return static
-     */
-    public function setClosedFlag()
-    {
-        $this->setAttribute('is_closed', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset closed flag.
-     *
-     * @return static
-     */
-    public function unsetClosedFlag()
-    {
-        $this->setAttribute('is_closed', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is closed.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasClosedFlagHelpers
      */
     public function close(): void
     {
-        $this->setClosedFlag()->save();
+        $this->setAttribute('is_closed', true);
+        $this->save();
 
         $this->fireModelEvent('closed', false);
     }
@@ -83,7 +60,8 @@ trait HasClosedFlagHelpers
      */
     public function open(): void
     {
-        $this->unsetClosedFlag()->save();
+        $this->setAttribute('is_closed', false);
+        $this->save();
 
         $this->fireModelEvent('opened', false);
     }

--- a/src/Traits/Inverse/HasDraftedAtHelpers.php
+++ b/src/Traits/Inverse/HasDraftedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasDraftedAtHelpers
     }
 
     /**
-     * Set drafted flag.
-     *
-     * @return static
-     */
-    public function setDraftedFlag()
-    {
-        $this->setAttribute('drafted_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset drafted flag.
-     *
-     * @return static
-     */
-    public function unsetDraftedFlag()
-    {
-        $this->setAttribute('drafted_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is drafted.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasDraftedAtHelpers
      */
     public function draft(): void
     {
-        $this->setDraftedFlag()->save();
+        $this->setAttribute('drafted_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('drafted', false);
     }
@@ -85,7 +62,8 @@ trait HasDraftedAtHelpers
      */
     public function undraft(): void
     {
-        $this->unsetDraftedFlag()->save();
+        $this->setAttribute('drafted_at', null);
+        $this->save();
 
         $this->fireModelEvent('undrafted', false);
     }

--- a/src/Traits/Inverse/HasDraftedFlagHelpers.php
+++ b/src/Traits/Inverse/HasDraftedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasDraftedFlagHelpers
     }
 
     /**
-     * Set drafted flag.
-     *
-     * @return static
-     */
-    public function setDraftedFlag()
-    {
-        $this->setAttribute('is_drafted', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset drafted flag.
-     *
-     * @return static
-     */
-    public function unsetDraftedFlag()
-    {
-        $this->setAttribute('is_drafted', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is drafted.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasDraftedFlagHelpers
      */
     public function draft(): void
     {
-        $this->setDraftedFlag()->save();
+        $this->setAttribute('is_drafted', true);
+        $this->save();
 
         $this->fireModelEvent('drafted', false);
     }
@@ -83,7 +60,8 @@ trait HasDraftedFlagHelpers
      */
     public function undraft(): void
     {
-        $this->unsetDraftedFlag()->save();
+        $this->setAttribute('is_drafted', false);
+        $this->save();
 
         $this->fireModelEvent('undrafted', false);
     }

--- a/src/Traits/Inverse/HasEndedAtHelpers.php
+++ b/src/Traits/Inverse/HasEndedAtHelpers.php
@@ -23,30 +23,6 @@ trait HasEndedAtHelpers
     }
 
     /**
-     * Set end flag.
-     *
-     * @return static
-     */
-    public function setEndedFlag()
-    {
-        $this->setAttribute('ended_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset end flag.
-     *
-     * @return static
-     */
-    public function unsetEndedFlag()
-    {
-        $this->setAttribute('ended_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is end.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasEndedAtHelpers
      */
     public function end(): void
     {
-        $this->setEndedFlag()->save();
+        $this->setAttribute('ended_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('ended', false);
     }
@@ -85,7 +62,8 @@ trait HasEndedAtHelpers
      */
     public function unend(): void
     {
-        $this->unsetEndedFlag()->save();
+        $this->setAttribute('ended_at', null);
+        $this->save();
 
         $this->fireModelEvent('unended', false);
     }

--- a/src/Traits/Inverse/HasEndedFlagHelpers.php
+++ b/src/Traits/Inverse/HasEndedFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasEndedFlagHelpers
     }
 
     /**
-     * Set ended flag.
-     *
-     * @return static
-     */
-    public function setEndedFlag()
-    {
-        $this->setAttribute('is_ended', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset ended flag.
-     *
-     * @return static
-     */
-    public function unsetEndedFlag()
-    {
-        $this->setAttribute('is_ended', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is ended.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasEndedFlagHelpers
      */
     public function end(): void
     {
-        $this->setEndedFlag()->save();
+        $this->setAttribute('is_ended', true);
+        $this->save();
 
         $this->fireModelEvent('ended', false);
     }
@@ -83,7 +60,8 @@ trait HasEndedFlagHelpers
      */
     public function unend(): void
     {
-        $this->unsetEndedFlag()->save();
+        $this->setAttribute('is_ended', false);
+        $this->save();
 
         $this->fireModelEvent('unended', false);
     }

--- a/src/Traits/Inverse/HasExpiredAtHelpers.php
+++ b/src/Traits/Inverse/HasExpiredAtHelpers.php
@@ -23,30 +23,6 @@ trait HasExpiredAtHelpers
     }
 
     /**
-     * Set expired flag.
-     *
-     * @return static
-     */
-    public function setExpiredFlag()
-    {
-        $this->setAttribute('expired_at', Date::now());
-
-        return $this;
-    }
-
-    /**
-     * Unset expired flag.
-     *
-     * @return static
-     */
-    public function unsetExpiredFlag()
-    {
-        $this->setAttribute('expired_at', null);
-
-        return $this;
-    }
-
-    /**
      * If entity is expired.
      *
      * @return bool
@@ -73,7 +49,8 @@ trait HasExpiredAtHelpers
      */
     public function expire(): void
     {
-        $this->setExpiredFlag()->save();
+        $this->setAttribute('expired_at', Date::now());
+        $this->save();
 
         $this->fireModelEvent('expired', false);
     }
@@ -85,7 +62,8 @@ trait HasExpiredAtHelpers
      */
     public function unexpire(): void
     {
-        $this->unsetExpiredFlag()->save();
+        $this->setAttribute('expired_at', null);
+        $this->save();
 
         $this->fireModelEvent('unexpired', false);
     }

--- a/src/Traits/Inverse/HasExpiredFlagHelpers.php
+++ b/src/Traits/Inverse/HasExpiredFlagHelpers.php
@@ -21,30 +21,6 @@ trait HasExpiredFlagHelpers
     }
 
     /**
-     * Set expired flag.
-     *
-     * @return static
-     */
-    public function setExpiredFlag()
-    {
-        $this->setAttribute('is_expired', true);
-
-        return $this;
-    }
-
-    /**
-     * Unset expired flag.
-     *
-     * @return static
-     */
-    public function unsetExpiredFlag()
-    {
-        $this->setAttribute('is_expired', false);
-
-        return $this;
-    }
-
-    /**
      * If entity is expired.
      *
      * @return bool
@@ -71,7 +47,8 @@ trait HasExpiredFlagHelpers
      */
     public function expire(): void
     {
-        $this->setExpiredFlag()->save();
+        $this->setAttribute('is_expired', true);
+        $this->save();
 
         $this->fireModelEvent('expired', false);
     }
@@ -83,7 +60,8 @@ trait HasExpiredFlagHelpers
      */
     public function unexpire(): void
     {
-        $this->unsetExpiredFlag()->save();
+        $this->setAttribute('is_expired', false);
+        $this->save();
 
         $this->fireModelEvent('unexpired', false);
     }

--- a/tests/Unit/Traits/Classic/HasAcceptedAtHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasAcceptedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasAcceptedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_accepted_flag(): void
-    {
-        $entity = factory(EntityWithAcceptedAt::class)->create([
-            'accepted_at' => null,
-        ]);
-
-        $entity->setAcceptedFlag();
-
-        $this->assertNotNull($entity->accepted_at);
-    }
-
-    /** @test */
-    public function it_can_unset_accepted_flag(): void
-    {
-        $entity = factory(EntityWithAcceptedAt::class)->create([
-            'accepted_at' => Date::now(),
-        ]);
-
-        $entity->unsetAcceptedFlag();
-
-        $this->assertNull($entity->accepted_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_accepted(): void
     {
         $acceptedEntity = factory(EntityWithAcceptedAt::class)->create([

--- a/tests/Unit/Traits/Classic/HasAcceptedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasAcceptedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasAcceptedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_accepted_flag(): void
-    {
-        $entity = factory(EntityWithAcceptedFlag::class)->create([
-            'is_accepted' => false,
-        ]);
-
-        $entity->setAcceptedFlag();
-
-        $this->assertTrue($entity->is_accepted);
-    }
-
-    /** @test */
-    public function it_can_unset_accepted_flag(): void
-    {
-        $entity = factory(EntityWithAcceptedFlag::class)->create([
-            'is_accepted' => true,
-        ]);
-
-        $entity->unsetAcceptedFlag();
-
-        $this->assertFalse($entity->is_accepted);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_accepted(): void
     {
         $acceptedEntity = factory(EntityWithAcceptedFlag::class)->create([

--- a/tests/Unit/Traits/Classic/HasActiveFlagHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasActiveFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasActiveFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_active_flag(): void
-    {
-        $entity = factory(EntityWithActiveFlag::class)->create([
-            'is_active' => false,
-        ]);
-
-        $entity->setActivatedFlag();
-
-        $this->assertTrue($entity->is_active);
-    }
-
-    /** @test */
-    public function it_can_unset_active_flag(): void
-    {
-        $entity = factory(EntityWithActiveFlag::class)->create([
-            'is_active' => true,
-        ]);
-
-        $entity->unsetActivatedFlag();
-
-        $this->assertFalse($entity->is_active);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_active(): void
     {
         $activatedEntity = factory(EntityWithActiveFlag::class)->create([

--- a/tests/Unit/Traits/Classic/HasApprovedAtHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasApprovedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasApprovedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_approved_flag(): void
-    {
-        $entity = factory(EntityWithApprovedAt::class)->create([
-            'approved_at' => null,
-        ]);
-
-        $entity->setApprovedFlag();
-
-        $this->assertNotNull($entity->approved_at);
-    }
-
-    /** @test */
-    public function it_can_unset_approved_flag(): void
-    {
-        $entity = factory(EntityWithApprovedAt::class)->create([
-            'approved_at' => Date::now(),
-        ]);
-
-        $entity->unsetApprovedFlag();
-
-        $this->assertNull($entity->approved_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_approved(): void
     {
         $approvedEntity = factory(EntityWithApprovedAt::class)->create([

--- a/tests/Unit/Traits/Classic/HasApprovedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasApprovedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasApprovedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_approved_flag(): void
-    {
-        $entity = factory(EntityWithApprovedFlag::class)->create([
-            'is_approved' => false,
-        ]);
-
-        $entity->setApprovedFlag();
-
-        $this->assertTrue($entity->is_approved);
-    }
-
-    /** @test */
-    public function it_can_unset_approved_flag(): void
-    {
-        $entity = factory(EntityWithApprovedFlag::class)->create([
-            'is_approved' => true,
-        ]);
-
-        $entity->unsetApprovedFlag();
-
-        $this->assertFalse($entity->is_approved);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_approved(): void
     {
         $approvedEntity = factory(EntityWithApprovedFlag::class)->create([

--- a/tests/Unit/Traits/Classic/HasInvitedAtHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasInvitedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasInvitedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_invited_flag(): void
-    {
-        $entity = factory(EntityWithInvitedAt::class)->create([
-            'invited_at' => null,
-        ]);
-
-        $entity->setInvitedFlag();
-
-        $this->assertNotNull($entity->invited_at);
-    }
-
-    /** @test */
-    public function it_can_unset_invited_flag(): void
-    {
-        $entity = factory(EntityWithInvitedAt::class)->create([
-            'invited_at' => Date::now(),
-        ]);
-
-        $entity->unsetInvitedFlag();
-
-        $this->assertNull($entity->invited_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_invited(): void
     {
         $invitedEntity = factory(EntityWithInvitedAt::class)->create([

--- a/tests/Unit/Traits/Classic/HasInvitedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasInvitedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasInvitedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_invited_flag(): void
-    {
-        $entity = factory(EntityWithInvitedFlag::class)->create([
-            'is_invited' => false,
-        ]);
-
-        $entity->setInvitedFlag();
-
-        $this->assertTrue($entity->is_invited);
-    }
-
-    /** @test */
-    public function it_can_unset_invited_flag(): void
-    {
-        $entity = factory(EntityWithInvitedFlag::class)->create([
-            'is_invited' => true,
-        ]);
-
-        $entity->unsetInvitedFlag();
-
-        $this->assertFalse($entity->is_invited);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_invited(): void
     {
         $invitedEntity = factory(EntityWithInvitedFlag::class)->create([

--- a/tests/Unit/Traits/Classic/HasKeptFlagHelperTest.php
+++ b/tests/Unit/Traits/Classic/HasKeptFlagHelperTest.php
@@ -40,30 +40,6 @@ final class HasKeptFlagHelperTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_kept_flag(): void
-    {
-        $entity = factory(EntityWithKeptFlag::class)->create([
-            'is_kept' => false,
-        ]);
-
-        $entity->setKeptFlag();
-
-        $this->assertTrue($entity->is_kept);
-    }
-
-    /** @test */
-    public function it_can_unset_kept_flag(): void
-    {
-        $entity = factory(EntityWithKeptFlag::class)->create([
-            'is_kept' => true,
-        ]);
-
-        $entity->unsetKeptFlag();
-
-        $this->assertFalse($entity->is_kept);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_kept(): void
     {
         $keptEntity = factory(EntityWithKeptFlag::class)->create([

--- a/tests/Unit/Traits/Classic/HasPublishedAtHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasPublishedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasPublishedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_published_flag(): void
-    {
-        $entity = factory(EntityWithPublishedAt::class)->create([
-            'published_at' => null,
-        ]);
-
-        $entity->setPublishedFlag();
-
-        $this->assertNotNull($entity->published_at);
-    }
-
-    /** @test */
-    public function it_can_unset_published_flag(): void
-    {
-        $entity = factory(EntityWithPublishedAt::class)->create([
-            'published_at' => Date::now(),
-        ]);
-
-        $entity->unsetPublishedFlag();
-
-        $this->assertNull($entity->published_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_published(): void
     {
         $publishedEntity = factory(EntityWithPublishedAt::class)->create([

--- a/tests/Unit/Traits/Classic/HasPublishedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasPublishedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasPublishedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_published_flag(): void
-    {
-        $entity = factory(EntityWithPublishedFlag::class)->create([
-            'is_published' => false,
-        ]);
-
-        $entity->setPublishedFlag();
-
-        $this->assertTrue($entity->is_published);
-    }
-
-    /** @test */
-    public function it_can_unset_published_flag(): void
-    {
-        $entity = factory(EntityWithPublishedFlag::class)->create([
-            'is_published' => true,
-        ]);
-
-        $entity->unsetPublishedFlag();
-
-        $this->assertFalse($entity->is_published);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_published(): void
     {
         $publishedEntity = factory(EntityWithPublishedFlag::class)->create([

--- a/tests/Unit/Traits/Classic/HasVerifiedAtHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasVerifiedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasVerifiedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_verified_flag(): void
-    {
-        $entity = factory(EntityWithVerifiedAt::class)->create([
-            'verified_at' => null,
-        ]);
-
-        $entity->setVerifiedFlag();
-
-        $this->assertNotNull($entity->verified_at);
-    }
-
-    /** @test */
-    public function it_can_unset_verified_flag(): void
-    {
-        $entity = factory(EntityWithVerifiedAt::class)->create([
-            'verified_at' => Date::now(),
-        ]);
-
-        $entity->unsetVerifiedFlag();
-
-        $this->assertNull($entity->verified_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_verified(): void
     {
         $verifiedEntity = factory(EntityWithVerifiedAt::class)->create([

--- a/tests/Unit/Traits/Classic/HasVerifiedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Classic/HasVerifiedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasVerifiedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_verified_flag(): void
-    {
-        $entity = factory(EntityWithVerifiedFlag::class)->create([
-            'is_verified' => false,
-        ]);
-
-        $entity->setVerifiedFlag();
-
-        $this->assertTrue($entity->is_verified);
-    }
-
-    /** @test */
-    public function it_can_unset_verified_flag(): void
-    {
-        $entity = factory(EntityWithVerifiedFlag::class)->create([
-            'is_verified' => true,
-        ]);
-
-        $entity->unsetVerifiedFlag();
-
-        $this->assertFalse($entity->is_verified);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_verified(): void
     {
         $verifiedEntity = factory(EntityWithVerifiedFlag::class)->create([

--- a/tests/Unit/Traits/Inverse/HasArchivedAtHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasArchivedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasArchivedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_archived_flag(): void
-    {
-        $entity = factory(EntityWithArchivedAt::class)->create([
-            'archived_at' => null,
-        ]);
-
-        $entity->setArchivedFlag();
-
-        $this->assertNotNull($entity->archived_at);
-    }
-
-    /** @test */
-    public function it_can_unset_archived_flag(): void
-    {
-        $entity = factory(EntityWithArchivedAt::class)->create([
-            'archived_at' => Date::now(),
-        ]);
-
-        $entity->unsetArchivedFlag();
-
-        $this->assertNull($entity->archived_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_archived(): void
     {
         $archivedEntity = factory(EntityWithArchivedAt::class)->create([

--- a/tests/Unit/Traits/Inverse/HasArchivedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasArchivedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasArchivedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_archived_flag(): void
-    {
-        $entity = factory(EntityWithArchivedFlag::class)->create([
-            'is_archived' => false,
-        ]);
-
-        $entity->setArchivedFlag();
-
-        $this->assertTrue($entity->is_archived);
-    }
-
-    /** @test */
-    public function it_can_unset_archived_flag(): void
-    {
-        $entity = factory(EntityWithArchivedFlag::class)->create([
-            'is_archived' => true,
-        ]);
-
-        $entity->unsetArchivedFlag();
-
-        $this->assertFalse($entity->is_archived);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_archived(): void
     {
         $archivedEntity = factory(EntityWithArchivedFlag::class)->create([

--- a/tests/Unit/Traits/Inverse/HasClosedAtHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasClosedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasClosedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_closed_flag(): void
-    {
-        $entity = factory(EntityWithClosedAt::class)->create([
-            'closed_at' => null,
-        ]);
-
-        $entity->setClosedFlag();
-
-        $this->assertNotNull($entity->closed_at);
-    }
-
-    /** @test */
-    public function it_can_unset_closed_flag(): void
-    {
-        $entity = factory(EntityWithClosedAt::class)->create([
-            'closed_at' => Date::now(),
-        ]);
-
-        $entity->unsetClosedFlag();
-
-        $this->assertNull($entity->closed_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_closed(): void
     {
         $closedEntity = factory(EntityWithClosedAt::class)->create([

--- a/tests/Unit/Traits/Inverse/HasClosedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasClosedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasClosedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_closed_flag(): void
-    {
-        $entity = factory(EntityWithClosedFlag::class)->create([
-            'is_closed' => false,
-        ]);
-
-        $entity->setClosedFlag();
-
-        $this->assertTrue($entity->is_closed);
-    }
-
-    /** @test */
-    public function it_can_unset_closed_flag(): void
-    {
-        $entity = factory(EntityWithClosedFlag::class)->create([
-            'is_closed' => true,
-        ]);
-
-        $entity->unsetClosedFlag();
-
-        $this->assertFalse($entity->is_closed);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_closed(): void
     {
         $closedEntity = factory(EntityWithClosedFlag::class)->create([

--- a/tests/Unit/Traits/Inverse/HasDraftedAtHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasDraftedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasDraftedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_drafted_flag(): void
-    {
-        $entity = factory(EntityWithDraftedAt::class)->create([
-            'drafted_at' => null,
-        ]);
-
-        $entity->setDraftedFlag();
-
-        $this->assertNotNull($entity->drafted_at);
-    }
-
-    /** @test */
-    public function it_can_unset_drafted_flag(): void
-    {
-        $entity = factory(EntityWithDraftedAt::class)->create([
-            'drafted_at' => Date::now(),
-        ]);
-
-        $entity->unsetDraftedFlag();
-
-        $this->assertNull($entity->drafted_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_drafted(): void
     {
         $draftedEntity = factory(EntityWithDraftedAt::class)->create([

--- a/tests/Unit/Traits/Inverse/HasDraftedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasDraftedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasDraftedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_drafted_flag(): void
-    {
-        $entity = factory(EntityWithDraftedFlag::class)->create([
-            'is_drafted' => false,
-        ]);
-
-        $entity->setDraftedFlag();
-
-        $this->assertTrue($entity->is_drafted);
-    }
-
-    /** @test */
-    public function it_can_unset_drafted_flag(): void
-    {
-        $entity = factory(EntityWithDraftedFlag::class)->create([
-            'is_drafted' => true,
-        ]);
-
-        $entity->unsetDraftedFlag();
-
-        $this->assertFalse($entity->is_drafted);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_drafted(): void
     {
         $draftedEntity = factory(EntityWithDraftedFlag::class)->create([

--- a/tests/Unit/Traits/Inverse/HasEndedAtHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasEndedAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasEndedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_ended_flag(): void
-    {
-        $entity = factory(EntityWithEndedAt::class)->create([
-            'ended_at' => null,
-        ]);
-
-        $entity->setEndedFlag();
-
-        $this->assertNotNull($entity->ended_at);
-    }
-
-    /** @test */
-    public function it_can_unset_ended_flag(): void
-    {
-        $entity = factory(EntityWithEndedAt::class)->create([
-            'ended_at' => Date::now(),
-        ]);
-
-        $entity->unsetEndedFlag();
-
-        $this->assertNull($entity->ended_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_ended(): void
     {
         $endedEntity = factory(EntityWithEndedAt::class)->create([

--- a/tests/Unit/Traits/Inverse/HasEndedFlagHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasEndedFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasEndedFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_ended_flag(): void
-    {
-        $entity = factory(EntityWithEndedFlag::class)->create([
-            'is_ended' => false,
-        ]);
-
-        $entity->setEndedFlag();
-
-        $this->assertTrue($entity->is_ended);
-    }
-
-    /** @test */
-    public function it_can_unset_ended_flag(): void
-    {
-        $entity = factory(EntityWithEndedFlag::class)->create([
-            'is_ended' => true,
-        ]);
-
-        $entity->unsetEndedFlag();
-
-        $this->assertFalse($entity->is_ended);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_ended(): void
     {
         $endedEntity = factory(EntityWithEndedFlag::class)->create([

--- a/tests/Unit/Traits/Inverse/HasExpiredAtHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasExpiredAtHelpersTest.php
@@ -32,30 +32,6 @@ final class HasExpiredAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_expired_flag(): void
-    {
-        $entity = factory(EntityWithExpiredAt::class)->create([
-            'expired_at' => null,
-        ]);
-
-        $entity->setExpiredFlag();
-
-        $this->assertNotNull($entity->expired_at);
-    }
-
-    /** @test */
-    public function it_can_unset_expired_flag(): void
-    {
-        $entity = factory(EntityWithExpiredAt::class)->create([
-            'expired_at' => Date::now(),
-        ]);
-
-        $entity->unsetExpiredFlag();
-
-        $this->assertNull($entity->expired_at);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_expired(): void
     {
         $expiredEntity = factory(EntityWithExpiredAt::class)->create([

--- a/tests/Unit/Traits/Inverse/HasExpiredFlagHelpersTest.php
+++ b/tests/Unit/Traits/Inverse/HasExpiredFlagHelpersTest.php
@@ -39,30 +39,6 @@ final class HasExpiredFlagHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_expired_flag(): void
-    {
-        $entity = factory(EntityWithExpiredFlag::class)->create([
-            'is_expired' => false,
-        ]);
-
-        $entity->setExpiredFlag();
-
-        $this->assertTrue($entity->is_expired);
-    }
-
-    /** @test */
-    public function it_can_unset_expired_flag(): void
-    {
-        $entity = factory(EntityWithExpiredFlag::class)->create([
-            'is_expired' => true,
-        ]);
-
-        $entity->unsetExpiredFlag();
-
-        $this->assertFalse($entity->is_expired);
-    }
-
-    /** @test */
     public function it_can_check_if_entity_is_expired(): void
     {
         $expiredEntity = factory(EntityWithExpiredFlag::class)->create([


### PR DESCRIPTION
Attribute mutator `set*` & `unset*` methods from all helper classes were removed. They were not documented and never used outside of the helper classes.